### PR TITLE
OpenSCAD icon gradient fix

### DIFF
--- a/Numix-Circle/48x48/apps/openscad.svg
+++ b/Numix-Circle/48x48/apps/openscad.svg
@@ -14,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.48.5 r10040"
-   sodipodi:docname="flightgear.svg">
+   sodipodi:docname="openscad.svg">
   <metadata
      id="metadata331">
     <rdf:RDF>
@@ -36,12 +36,12 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1052"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
      id="namedview329"
-     showgrid="true"
-     inkscape:zoom="16.850355"
-     inkscape:cx="26.782007"
+     showgrid="false"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="23.844533"
      inkscape:cy="20.148505"
      inkscape:window-x="0"
      inkscape:window-y="28"
@@ -1474,11 +1474,11 @@
       <stop
          id="stop3202"
          offset="0"
-         style="stop-color:#fefefe;stop-opacity:1;" />
+         style="stop-color:#f4f4f4;stop-opacity:1;" />
       <stop
          id="stop3204"
          offset="1"
-         style="stop-color:#e2e2e2;stop-opacity:1;" />
+         style="stop-color:#eaeaea;stop-opacity:1;" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"


### PR DESCRIPTION
Fixed the overly harsh gradient (was 30L)
Before:
![openscad_ori](https://cloud.githubusercontent.com/assets/7050624/5691464/e59a0fb6-98c7-11e4-896d-96d3f619a58f.png)
After:
![openscad](https://cloud.githubusercontent.com/assets/7050624/5691467/ebbf863c-98c7-11e4-8044-f02a76205833.png)

