### PR TITLE
Icon for ReText. Fixes #1425

### DIFF
--- a/Numix-Circle/48x48/apps/retext.svg
+++ b/Numix-Circle/48x48/apps/retext.svg
@@ -350,34 +350,37 @@
          id="g3995" />
     </g>
   </g>
-  <path
-     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 19.5,18 2.5,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2.5,0 0,2 c 1.620817,0 3.096815,0.31101 3.78125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2.5,0 z"
-     id="path3055"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="csssssccsscscscsssscc" />
-  <path
-     style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 18,16 3,0 0,15 -3,1e-6 z"
-     id="rect3028"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
-  <path
-     style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 18,15.999996 1.5,-2e-6 0,15.000005 L 18,31 z"
-     id="rect3020"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccc" />
-  <path
-     inkscape:connector-curvature="0"
-     id="path3024"
-     d="M 18,31.000002 21,31 19.5,34.999998 z"
-     style="fill:#ffe680;stroke:none"
-     sodipodi:nodetypes="cccc" />
-  <path
-     sodipodi:nodetypes="cccc"
-     inkscape:connector-curvature="0"
-     id="path3030"
-     d="m 20.25,33.000001 -0.75,2 L 18.75,33 z"
-     style="fill:#191919;fill-opacity:1;stroke:none" />
+  <g
+     id="g3036">
+    <path
+       sodipodi:nodetypes="csssssccsscscscsssscc"
+       inkscape:connector-curvature="0"
+       id="path3055"
+       d="m 19.5,18 2.5,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2.5,0 0,2 c 1.620817,0 3.096815,0.31101 3.78125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2.5,0 z"
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3028"
+       d="m 18,16 3,0 0,15 -3,1e-6 z"
+       style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="rect3020"
+       d="m 18,15.999996 1.5,-2e-6 0,15.000005 L 18,31 z"
+       style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#ffe680;stroke:none"
+       d="M 18,31.000002 21,31 19.5,34.999998 z"
+       id="path3024"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#191919;fill-opacity:1;stroke:none"
+       d="m 20.25,33.000001 -0.75,2 L 18.75,33 z"
+       id="path3030"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+  </g>
 </svg>

--- a/Numix-Circle/48x48/apps/retext.svg
+++ b/Numix-Circle/48x48/apps/retext.svg
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview59"
      showgrid="false"
-     inkscape:zoom="22.627417"
-     inkscape:cx="20.793527"
-     inkscape:cy="23.343213"
+     inkscape:zoom="8"
+     inkscape:cx="20.020129"
+     inkscape:cy="19.807679"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -357,19 +357,19 @@
        inkscape:connector-curvature="0"
        id="path3055"
        d="m 19.5,18 2.5,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2.5,0 0,2 c 1.620817,0 3.096815,0.31101 3.78125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2.5,0 z"
-       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#212121;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans" />
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="rect3028"
        d="m 18,16 3,0 0,15 -3,1e-6 z"
-       style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+       style="fill:#b72727;fill-opacity:1;fill-rule:nonzero;stroke:none" />
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="rect3020"
        d="m 18,15.999996 1.5,-2e-6 0,15.000005 L 18,31 z"
-       style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+       style="fill:#d93535;fill-opacity:1;fill-rule:nonzero;stroke:none" />
     <path
        sodipodi:nodetypes="cccc"
        style="fill:#ffe680;stroke:none"
@@ -377,7 +377,7 @@
        id="path3024"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:#191919;fill-opacity:1;stroke:none"
+       style="fill:#212121;fill-opacity:1;stroke:none"
        d="m 20.25,33.000001 -0.75,2 L 18.75,33 z"
        id="path3030"
        inkscape:connector-curvature="0"

--- a/Numix-Circle/48x48/apps/retext.svg
+++ b/Numix-Circle/48x48/apps/retext.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.48.5 r10040"
    width="100%"
    height="100%"
-   sodipodi:docname="retext-.svg">
+   sodipodi:docname="retext.svg">
   <metadata
      id="metadata61">
     <rdf:RDF>
@@ -23,7 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,10 +39,10 @@
      inkscape:window-width="1366"
      inkscape:window-height="713"
      id="namedview59"
-     showgrid="true"
-     inkscape:zoom="16"
-     inkscape:cx="28.578502"
-     inkscape:cy="21.664281"
+     showgrid="false"
+     inkscape:zoom="22.627417"
+     inkscape:cx="20.793527"
+     inkscape:cy="23.343213"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -347,38 +347,37 @@
          inkscape:connector-curvature="0"
          sodipodi:nodetypes="cccccsssccsssccsssccsssccssscc" />
       <g
-         id="g3995">
-        <path
-           style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m -5.9349578,4.97819 3.0975631,-0.03272 -0.1683578,15.476173 -3.0975631,0.03272 z"
-           id="rect3020"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path3024"
-           d="m -6.1033156,20.454361 3.0975631,-0.03272 -1.5936769,4.143336 z"
-           style="fill:#ffe680;stroke:none"
-           sodipodi:nodetypes="cccc" />
-        <path
-           sodipodi:nodetypes="cccc"
-           inkscape:connector-curvature="0"
-           id="path3030"
-           d="M -3.802591,22.493312 -4.5994294,24.564981 -5.3513726,22.50967 z"
-           style="fill:#191919;fill-opacity:1;stroke:none" />
-      </g>
+         id="g3995" />
     </g>
   </g>
   <path
      style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-     d="m 20,18 2,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2,0 0,2 c 1.620817,0 2.596815,0.31101 3.28125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2,0 z"
+     d="m 19.5,18 2.5,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2.5,0 0,2 c 1.620817,0 3.096815,0.31101 3.78125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2.5,0 z"
      id="path3055"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="csssssccsscscscsssscc" />
   <path
      style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 19.5,16 1.5,0 0,15 -1.5,1e-6 z"
+     d="m 18,16 3,0 0,15 -3,1e-6 z"
      id="rect3028"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccc" />
+  <path
+     style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 18,15.999996 1.5,-2e-6 0,15.000005 L 18,31 z"
+     id="rect3020"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path3024"
+     d="M 18,31.000002 21,31 19.5,34.999998 z"
+     style="fill:#ffe680;stroke:none"
+     sodipodi:nodetypes="cccc" />
+  <path
+     sodipodi:nodetypes="cccc"
+     inkscape:connector-curvature="0"
+     id="path3030"
+     d="m 20.25,33.000001 -0.75,2 L 18.75,33 z"
+     style="fill:#191919;fill-opacity:1;stroke:none" />
 </svg>

--- a/Numix-Circle/48x48/apps/retext.svg
+++ b/Numix-Circle/48x48/apps/retext.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.48.5 r10040"
    width="100%"
    height="100%"
-   sodipodi:docname="retext.svg">
+   sodipodi:docname="retext-.svg">
   <metadata
      id="metadata61">
     <rdf:RDF>
@@ -23,7 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,10 +39,10 @@
      inkscape:window-width="1366"
      inkscape:window-height="713"
      id="namedview59"
-     showgrid="false"
+     showgrid="true"
      inkscape:zoom="16"
-     inkscape:cx="28.085937"
-     inkscape:cy="24.391757"
+     inkscape:cx="28.578502"
+     inkscape:cy="21.664281"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -162,10 +162,10 @@
      style="opacity:0.1;fill:#000000">
     <path
        style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       d="m 15.916665,11 1.833332,0 0,3 1.833334,0 0,-3 1.833333,0 0,3 1.833333,0 0,-3 1.833334,0 0,3 1.833333,0 0,-3 1.833333,0 0,3 1.833334,0 0,-3 1.833333,0 0,3 1.833333,0 0,-3 1.833335,0 -3e-6,26 -20.166667,0 z"
+       d="m 15.916664,11 0,26 20.166666,0 0,-26 -1.833333,0 0,3 c 0,0.552285 -0.410406,1 -0.916667,1 -0.506261,0 -0.916666,-0.447715 -0.916666,-1 l 0,-3 -1.833334,0 0,3 c 0,0.552285 -0.410405,1 -0.916666,1 -0.506262,0 -0.916667,-0.447715 -0.916667,-1 l 0,-3 -1.833333,0 0,3 c 0,0.552285 -0.410406,1 -0.916667,1 -0.506261,0 -0.916667,-0.447715 -0.916667,-1 l 0,-3 -1.833333,0 0,3 c 0,0.552285 -0.410405,1 -0.916667,1 -0.506261,0 -0.916666,-0.447715 -0.916666,-1 l 0,-3 -1.833334,0 0,3 c 0,0.552285 -0.410405,1 -0.916666,1 -0.506262,0 -0.916667,-0.447715 -0.916667,-1 l 0,-3 z"
        id="rect3150"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+       sodipodi:nodetypes="cccccsssccsssccsssccsssccssscc" />
     <g
        id="g3154"
        transform="matrix(0.36,0,0,0.36521738,21.52,20.878261)"
@@ -340,21 +340,14 @@
     <g
        id="g4003">
       <path
+         style="fill:#e3dedb;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 13,11 0,26 22,0 0,-26 -2,0 0,2 c 0,0.552285 -0.447715,1 -1,1 -0.552285,0 -1,-0.447715 -1,-1 l 0,-2 -2,0 0,2 c 0,0.552285 -0.447715,1 -1,1 -0.552285,0 -1,-0.447715 -1,-1 l 0,-2 -2,0 0,2 c 0,0.552285 -0.447715,1 -1,1 -0.552285,0 -1,-0.447715 -1,-1 l 0,-2 -2,0 0,2 c 0,0.552285 -0.447715,1 -1,1 -0.552285,0 -1,-0.447715 -1,-1 l 0,-2 -2,0 0,2 c 0,0.552285 -0.447715,1 -1,1 -0.552285,0 -1,-0.447715 -1,-1 l 0,-2 z"
          transform="matrix(1.032521,-0.01090602,-0.01122385,1.0317448,-24.340755,-11.333421)"
-         sodipodi:nodetypes="ccccccccccccccccccccccccc"
-         inkscape:connector-curvature="0"
          id="rect3042"
-         d="m 13,11 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,26 -22,0 z"
-         style="fill:#e3dedb;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccccsssccsssccsssccsssccssscc" />
       <g
          id="g3995">
-        <path
-           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
-           d="m 20,16 0,2 2,0 c 2.433333,0 4.035888,0.283827 4.875,0.75 C 27.714112,19.216173 28,19.722222 28,21 28,22.277778 27.714112,22.783827 26.875,23.25 26.035888,23.716173 24.433333,24 22,24 l -2,0 0,2 c 1.63319,0 2.619845,0.282342 3.28125,0.6875 0.661405,0.405158 1.060478,0.976708 1.46875,1.78125 0.816544,1.609085 1.435999,4.139797 3.71875,6.53125 L 30,33.625 C 28.082751,31.616453 27.517706,29.506415 26.53125,27.5625 26.208622,26.926728 25.782974,26.319175 25.25,25.78125 26.264754,25.630835 27.143538,25.406368 27.875,25 29.285888,24.216173 30,22.722222 30,21 30,19.277778 29.285888,17.783827 27.875,17 26.464112,16.216173 24.566667,16 22,16 z"
-           id="path3845"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccsssssccssccscssssc"
-           transform="matrix(1.032521,-0.01090602,-0.01122385,1.0317448,-24.340755,-11.333421)" />
         <path
            style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none"
            d="m -5.9349578,4.97819 3.0975631,-0.03272 -0.1683578,15.476173 -3.0975631,0.03272 z"
@@ -368,18 +361,24 @@
            style="fill:#ffe680;stroke:none"
            sodipodi:nodetypes="cccc" />
         <path
-           style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m -4.3861763,4.9618292 1.5487816,-0.016359 -0.1683578,15.4761728 -1.5487816,0.01636 z"
-           id="rect3028"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
            sodipodi:nodetypes="cccc"
            inkscape:connector-curvature="0"
            id="path3030"
-           d="m -3.7542677,22.482239 -0.8451617,2.082742 -0.7032188,-2.066388 z"
-           style="fill:#1a1a1a;stroke:none" />
+           d="M -3.802591,22.493312 -4.5994294,24.564981 -5.3513726,22.50967 z"
+           style="fill:#191919;fill-opacity:1;stroke:none" />
       </g>
     </g>
   </g>
+  <path
+     style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+     d="m 20,18 2,0 c 3.140285,0 4.677217,0.523961 5.3125,1.03125 C 27.947783,19.538539 28,20.085644 28,21 28,21.910673 27.95179,22.459762 27.3125,22.96875 26.673214,23.477738 25.128885,24 22,24 l -2,0 0,2 c 1.620817,0 2.596815,0.31101 3.28125,0.75 0.684435,0.43899 1.150397,1.056786 1.5625,1.875 0.824206,1.636428 1.350624,4.059605 3.45625,6.075 0.361057,0.426208 1.046261,0.37718 1.4,0 0.399259,-0.425717 0.390263,-1.026202 -0.0125,-1.41875 -1.628712,-1.558917 -2.07029,-3.592506 -3.0625,-5.5625 -0.363025,-0.720772 -0.890636,-1.398277 -1.53125,-2 1.478229,-0.228151 2.69793,-0.573787 3.46875,-1.1875 C 29.807205,23.540238 30,22.089327 30,21 30,19.914356 29.805683,18.461461 28.5625,17.46875 27.319317,16.476039 25.345851,16 22,16 l -2,0 z"
+     id="path3055"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csssssccsscscscsssscc" />
+  <path
+     style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 19.5,16 1.5,0 0,15 -1.5,1e-6 z"
+     id="rect3028"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccc" />
 </svg>

--- a/Numix-Circle/48x48/apps/retext.svg
+++ b/Numix-Circle/48x48/apps/retext.svg
@@ -1,1 +1,385 @@
-text-editor.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="retext.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="28.085937"
+     inkscape:cy="24.391757"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3040"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3863">
+      <stop
+         style="stop-color:#d93f3f;stop-opacity:1;"
+         offset="0"
+         id="stop3865" />
+      <stop
+         style="stop-color:#dc5050;stop-opacity:1;"
+         offset="1"
+         id="stop3867" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#333"
+         stop-opacity="1"
+         id="stop7"
+         offset="0"
+         style="stop-color:#eb5555;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#3d3d3d"
+         stop-opacity="1"
+         id="stop9"
+         style="stop-color:#ed6767;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-487214953">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-498702923">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3863"
+       id="linearGradient3869"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3869);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     transform="matrix(1.0909091,0,0,1,-3.3636332,1)"
+     id="g3148"
+     style="opacity:0.1;fill:#000000">
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       d="m 15.916665,11 1.833332,0 0,3 1.833334,0 0,-3 1.833333,0 0,3 1.833333,0 0,-3 1.833334,0 0,3 1.833333,0 0,-3 1.833333,0 0,3 1.833334,0 0,-3 1.833333,0 0,3 1.833333,0 0,-3 1.833335,0 -3e-6,26 -20.166667,0 z"
+       id="rect3150"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+    <g
+       id="g3154"
+       transform="matrix(0.36,0,0,0.36521738,21.52,20.878261)"
+       style="opacity:0.7;fill:#000000">
+      <path
+         transform="matrix(0.46383647,0,0,0.52304963,46.603773,4.0851067)"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         sodipodi:ry="4.7796612"
+         sodipodi:rx="5.3898306"
+         sodipodi:cy="18"
+         sodipodi:cx="-41.18644"
+         id="path3156"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3158"
+         sodipodi:cx="-41.18644"
+         sodipodi:cy="18"
+         sodipodi:rx="5.3898306"
+         sodipodi:ry="4.7796612"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         transform="matrix(0.46383647,0,0,0.52304963,39.603773,10.085107)" />
+      <path
+         transform="matrix(0.46383647,0,0,0.52304963,33.603773,16.085107)"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         sodipodi:ry="4.7796612"
+         sodipodi:rx="5.3898306"
+         sodipodi:cy="18"
+         sodipodi:cx="-41.18644"
+         id="path3160"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3162"
+         sodipodi:cx="-41.18644"
+         sodipodi:cy="18"
+         sodipodi:rx="5.3898306"
+         sodipodi:ry="4.7796612"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         transform="matrix(0.46383647,0,0,0.52304963,42.603773,16.085107)" />
+      <path
+         transform="matrix(0.46383647,0,0,0.52304963,49.603773,10.085107)"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         sodipodi:ry="4.7796612"
+         sodipodi:rx="5.3898306"
+         sodipodi:cy="18"
+         sodipodi:cx="-41.18644"
+         id="path3164"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3166"
+         sodipodi:cx="-41.18644"
+         sodipodi:cy="18"
+         sodipodi:rx="5.3898306"
+         sodipodi:ry="4.7796612"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         transform="matrix(0.46383647,0,0,0.52304963,51.603773,16.085107)" />
+      <path
+         transform="matrix(0.46383647,0,0,0.52304963,53.603773,22.085107)"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         sodipodi:ry="4.7796612"
+         sodipodi:rx="5.3898306"
+         sodipodi:cy="18"
+         sodipodi:cx="-41.18644"
+         id="path3168"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         transform="matrix(0.46383647,0,0,0.52304963,44.603773,22.085107)"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         sodipodi:ry="4.7796612"
+         sodipodi:rx="5.3898306"
+         sodipodi:cy="18"
+         sodipodi:cx="-41.18644"
+         id="path3170"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:type="arc" />
+      <path
+         sodipodi:type="arc"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         id="path3172"
+         sodipodi:cx="-41.18644"
+         sodipodi:cy="18"
+         sodipodi:rx="5.3898306"
+         sodipodi:ry="4.7796612"
+         d="m -35.796609,18 c 0,2.639734 -2.413109,4.779661 -5.389831,4.779661 -2.976721,0 -5.38983,-2.139927 -5.38983,-4.779661 0,-2.639734 2.413109,-4.779661 5.38983,-4.779661 2.976722,0 5.389831,2.139927 5.389831,4.779661 z"
+         transform="matrix(0.46383647,0,0,0.52304963,36.603773,22.085107)" />
+    </g>
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3174"
+       width="15"
+       height="1"
+       x="18"
+       y="16" />
+    <rect
+       y="19"
+       x="18"
+       height="1"
+       width="10"
+       id="rect3176"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       y="22"
+       x="18"
+       height="1"
+       width="15"
+       id="rect3178"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3180"
+       width="8"
+       height="1.0000004"
+       x="18"
+       y="25" />
+    <g
+       id="g3182"
+       transform="matrix(0.68965061,0.68022132,-0.66578267,0.70460687,40.466817,18.228738)"
+       style="fill:#000000">
+      <rect
+         y="5"
+         x="-8"
+         height="19"
+         width="2"
+         id="rect3184"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <rect
+         y="2"
+         x="-8"
+         height="3"
+         width="2"
+         id="rect3186"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path3188"
+         d="m -8,24 2,0 -1,4 z"
+         style="fill:#000000;stroke:none" />
+      <rect
+         y="4"
+         x="-8"
+         height="1"
+         width="2"
+         id="rect3190"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <rect
+         y="5"
+         x="-7"
+         height="19"
+         width="1"
+         id="rect3192"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path3194"
+         d="M -6.4814864,26 -7,28 -7.4919082,26 c 0.3532369,0 0.6571849,0 1.0104218,0 z"
+         style="fill:#000000;stroke:none" />
+    </g>
+  </g>
+  <g
+     id="g3032"
+     transform="matrix(0.96861457,0.0102387,0.01053709,0.96934327,23.696231,11.235193)">
+    <g
+       id="g4003">
+      <path
+         transform="matrix(1.032521,-0.01090602,-0.01122385,1.0317448,-24.340755,-11.333421)"
+         sodipodi:nodetypes="ccccccccccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect3042"
+         d="m 13,11 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,3 2,0 0,-3 2,0 0,26 -22,0 z"
+         style="fill:#e3dedb;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      <g
+         id="g3995">
+        <path
+           style="font-size:medium;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:normal;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#191919;fill-opacity:1;stroke:none;stroke-width:2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sans;-inkscape-font-specification:Sans"
+           d="m 20,16 0,2 2,0 c 2.433333,0 4.035888,0.283827 4.875,0.75 C 27.714112,19.216173 28,19.722222 28,21 28,22.277778 27.714112,22.783827 26.875,23.25 26.035888,23.716173 24.433333,24 22,24 l -2,0 0,2 c 1.63319,0 2.619845,0.282342 3.28125,0.6875 0.661405,0.405158 1.060478,0.976708 1.46875,1.78125 0.816544,1.609085 1.435999,4.139797 3.71875,6.53125 L 30,33.625 C 28.082751,31.616453 27.517706,29.506415 26.53125,27.5625 26.208622,26.926728 25.782974,26.319175 25.25,25.78125 26.264754,25.630835 27.143538,25.406368 27.875,25 29.285888,24.216173 30,22.722222 30,21 30,19.277778 29.285888,17.783827 27.875,17 26.464112,16.216173 24.566667,16 22,16 z"
+           id="path3845"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccsssssccssccscssssc"
+           transform="matrix(1.032521,-0.01090602,-0.01122385,1.0317448,-24.340755,-11.333421)" />
+        <path
+           style="fill:#df2525;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m -5.9349578,4.97819 3.0975631,-0.03272 -0.1683578,15.476173 -3.0975631,0.03272 z"
+           id="rect3020"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path3024"
+           d="m -6.1033156,20.454361 3.0975631,-0.03272 -1.5936769,4.143336 z"
+           style="fill:#ffe680;stroke:none"
+           sodipodi:nodetypes="cccc" />
+        <path
+           style="fill:#b92020;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m -4.3861763,4.9618292 1.5487816,-0.016359 -0.1683578,15.4761728 -1.5487816,0.01636 z"
+           id="rect3028"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path3030"
+           d="m -3.7542677,22.482239 -0.8451617,2.082742 -0.7032188,-2.066388 z"
+           style="fill:#1a1a1a;stroke:none" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for ReText, issue #1425
![retext](https://cloud.githubusercontent.com/assets/7050624/5697537/f9045bc4-99f3-11e4-9a9a-6a2446759bf7.png)
