### PR TITLE
Icons for QLandkarteGT and QMapShack. Fixes #1034

### DIFF
--- a/Numix-Circle/48x48/apps/QMapShack.svg
+++ b/Numix-Circle/48x48/apps/QMapShack.svg
@@ -1,0 +1,1 @@
+viking.svg

--- a/Numix-Circle/48x48/apps/qlandkartegt.svg
+++ b/Numix-Circle/48x48/apps/qlandkartegt.svg
@@ -1,0 +1,1 @@
+viking.svg


### PR DESCRIPTION
Icons for QLandkarteGT and QMapShack, issue #1034.
Icons as symbolic links to the existing Viking icon.