### PR TITLE
Fixed subtitleeditor link. Fixes #1480

### DIFF
--- a/Numix-Circle/48x48/apps/subtitleeditor.svg
+++ b/Numix-Circle/48x48/apps/subtitleeditor.svg
@@ -1,1 +1,1 @@
-gnome-subtitle.svg
+gnome-subtitles.svg


### PR DESCRIPTION
Fixed subtitleeditor link which was pointing to non-existing *gnome-subtitle.svg* . Fixes issue #1480