### PR TITLE
Enhanced icon for digiKam

### DIFF
--- a/Numix-Circle/48x48/apps/digikam.svg
+++ b/Numix-Circle/48x48/apps/digikam.svg
@@ -11,10 +11,10 @@
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r13725"
    width="100%"
    height="100%"
-   sodipodi:docname="digikam4.svg"
+   sodipodi:docname="digikam-c.svg"
    inkscape:export-filename="/home/ismael/Imágenes/icons.png"
    inkscape:export-xdpi="245"
    inkscape:export-ydpi="245">
@@ -26,7 +26,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -50,9 +50,9 @@
      inkscape:snap-smooth-nodes="false"
      inkscape:snap-midpoints="false"
      inkscape:snap-grids="true"
-     inkscape:zoom="16"
-     inkscape:cx="24.798075"
-     inkscape:cy="24.782662"
+     inkscape:zoom="8"
+     inkscape:cx="41.513936"
+     inkscape:cy="25.085963"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -68,155 +68,16 @@
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient6121">
-      <stop
-         style="stop-color:#cc5f50;stop-opacity:1;"
-         offset="0"
-         id="stop6123" />
-      <stop
-         style="stop-color:#d57a6e;stop-opacity:1;"
-         offset="1"
-         id="stop6125" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4393">
-      <stop
-         style="stop-color:#7d683e;stop-opacity:1;"
-         offset="0"
-         id="stop4395" />
-      <stop
-         style="stop-color:#7a6841;stop-opacity:1;"
-         offset="1"
-         id="stop4397" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4080">
-      <stop
-         id="stop4082"
-         offset="0"
-         style="stop-color:#156aa3;stop-opacity:1;" />
-      <stop
-         id="stop4084"
-         offset="1"
-         style="stop-color:#1a7cbe;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4072">
-      <stop
-         style="stop-color:#ffff00;stop-opacity:1;"
-         offset="0"
-         id="stop4074" />
-      <stop
-         style="stop-color:#ffff00;stop-opacity:0;"
-         offset="1"
-         id="stop4076" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3977">
-      <stop
-         style="stop-color:#ef6651;stop-opacity:1;"
-         offset="0"
-         id="stop3979" />
-      <stop
-         style="stop-color:#f17b69;stop-opacity:1;"
-         offset="1"
-         id="stop3981" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3936">
-      <stop
-         id="stop3938"
-         offset="0"
-         style="stop-color:#5880ff;stop-opacity:1;" />
-      <stop
-         id="stop3940"
-         offset="1"
-         style="stop-color:#9ab2ff;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3827">
-      <stop
-         style="stop-color:#3f3953;stop-opacity:1;"
-         offset="0"
-         id="stop3829" />
-      <stop
-         style="stop-color:#766b99;stop-opacity:1;"
-         offset="1"
-         id="stop3831" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3817">
-      <stop
-         id="stop3819"
-         offset="0"
-         style="stop-color:#655b85;stop-opacity:1;" />
-      <stop
-         id="stop3821"
-         offset="1"
-         style="stop-color:#3f3953;stop-opacity:1;" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3784">
-      <stop
-         style="stop-color:#655b85;stop-opacity:1;"
-         offset="0"
-         id="stop3786" />
-      <stop
-         style="stop-color:#3f3953;stop-opacity:1;"
-         offset="1"
-         id="stop3788" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient3040">
       <stop
-         style="stop-color:#f06758;stop-opacity:1;"
+         style="stop-color:#ff8275;stop-opacity:1;"
          offset="0"
          id="stop3042" />
       <stop
-         style="stop-color:#ee5646;stop-opacity:1;"
+         style="stop-color:#ff7061;stop-opacity:1;"
          offset="1"
          id="stop3044" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient3764"
-       x1="1"
-       x2="47"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-      <stop
-         stop-color="#333"
-         stop-opacity="1"
-         id="stop7" />
-      <stop
-         offset="1"
-         stop-color="#3d3d3d"
-         stop-opacity="1"
-         id="stop9" />
-    </linearGradient>
-    <clipPath
-       id="clipPath-799970715">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g12">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           fill="#1890d0"
-           id="path14" />
-      </g>
-    </clipPath>
-    <clipPath
-       id="clipPath-808101755">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g17">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           fill="#1890d0"
-           id="path19" />
-      </g>
-    </clipPath>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3040"
@@ -226,107 +87,6 @@
        x2="24"
        y2="47"
        gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3790"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3793"
-       gradientUnits="userSpaceOnUse"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3795"
-       gradientUnits="userSpaceOnUse"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3797"
-       gradientUnits="userSpaceOnUse"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3800"
-       gradientUnits="userSpaceOnUse"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699"
-       gradientTransform="translate(46,2)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3803"
-       gradientUnits="userSpaceOnUse"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699"
-       gradientTransform="translate(41,0)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3784"
-       id="linearGradient3806"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(41,0)"
-       x1="-34.270798"
-       y1="9.1876106"
-       x2="-10.895576"
-       y2="33.97699" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3827"
-       id="linearGradient3833"
-       x1="35.021236"
-       y1="36.603539"
-       x2="12.061947"
-       y2="11.148674"
-       gradientUnits="userSpaceOnUse" />
-    <clipPath
-       id="clipPath-283144270">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g12-4">
-        <path
-           style="fill:#1890d0"
-           inkscape:connector-curvature="0"
-           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           id="path14-9" />
-      </g>
-    </clipPath>
-    <clipPath
-       id="clipPath-295805906">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g17-9">
-        <path
-           style="fill:#1890d0"
-           inkscape:connector-curvature="0"
-           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           id="path19-8" />
-      </g>
-    </clipPath>
     <clipPath
        id="clipPath-070777050">
       <g
@@ -341,56 +101,12 @@
       </g>
     </clipPath>
     <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3808"
-       id="radialGradient3814"
-       cx="23.00012"
-       cy="23.993263"
-       fx="23.00012"
-       fy="23.993263"
-       r="12.000658"
-       gradientTransform="matrix(1,0,0,0.99987541,0,0.0029893)"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       id="linearGradient3808">
-      <stop
-         style="stop-color:#ff5858;stop-opacity:1;"
-         offset="0"
-         id="stop3810" />
-      <stop
-         style="stop-color:#ff8c8c;stop-opacity:1;"
-         offset="1"
-         id="stop3812" />
-    </linearGradient>
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4393"
-       id="radialGradient4399"
-       cx="16.652831"
-       cy="30.075977"
-       fx="16.652831"
-       fy="30.075977"
-       r="1.2092668"
-       gradientTransform="matrix(1,0,0,0.92253912,0.47243548,2.9465604)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient6121"
-       id="radialGradient6127"
-       cx="17"
-       cy="17"
-       fx="17"
-       fy="17"
-       r="3.4999998"
-       gradientTransform="matrix(0.85714285,0,0,0.85714285,2.4285718,1.9285676)"
-       gradientUnits="userSpaceOnUse" />
-    <radialGradient
        r="5.7119875"
        fy="33.305279"
        fx="24.475513"
        cy="33.305279"
        cx="24.475513"
-       gradientTransform="matrix(0.52521128,0,0,0.29419011,11.038365,20.679044)"
+       gradientTransform="matrix(0.61274648,0,0,0.34322181,8.9947566,19.592214)"
        gradientUnits="userSpaceOnUse"
        id="radialGradient4040"
        xlink:href="#linearGradient4143-0"
@@ -398,22 +114,14 @@
     <linearGradient
        id="linearGradient4143-0">
       <stop
-         style="stop-color:#284070;stop-opacity:0.78431374;"
+         style="stop-color:#2a4376;stop-opacity:0.78431374"
          offset="0"
          id="stop4145-4" />
       <stop
-         style="stop-color:#35538b;stop-opacity:0.12941177;"
+         style="stop-color:#375691;stop-opacity:0.12941177"
          offset="1"
          id="stop4147-3" />
     </linearGradient>
-    <radialGradient
-       id="radial1-9"
-       gradientUnits="userSpaceOnUse"
-       cx="6"
-       cy="17.292"
-       r="1"
-       gradientTransform="matrix(0.57142857,0,0,0.57142857,20.571429,16.261697)"
-       xlink:href="#radial0-2" />
     <radialGradient
        id="radial0-2"
        gradientUnits="userSpaceOnUse"
@@ -434,24 +142,6 @@
          id="stop24-68"
          style="stop-color:#6a97b6;stop-opacity:0.08474576;" />
     </radialGradient>
-    <radialGradient
-       id="radialGradient3985"
-       gradientUnits="userSpaceOnUse"
-       cx="6.7729998"
-       cy="5.927"
-       r="0.56400001"
-       gradientTransform="matrix(3.543307,0,0,3.543307,1.47638e-7,3.77575e-4)">
-      <stop
-         stop-color="#8eb0c7"
-         stop-opacity="1"
-         id="stop3987" />
-      <stop
-         offset="1"
-         stop-color="#8eb0c7"
-         stop-opacity="0"
-         id="stop3989"
-         style="stop-color:#81a7c1;stop-opacity:0.03921569;" />
-    </radialGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4174-9"
@@ -460,28 +150,18 @@
        y1="36.93475"
        x2="24.475513"
        y2="29.489677"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.46685441,0,0,0.34385152,12.573498,8.3279325)" />
     <linearGradient
        id="linearGradient4174-9">
       <stop
-         style="stop-color:#205867;stop-opacity:1;"
+         style="stop-color:#225d6c;stop-opacity:1"
          offset="0"
          id="stop4176-6" />
       <stop
-         style="stop-color:#2a768a;stop-opacity:0;"
+         style="stop-color:#2b7a8f;stop-opacity:0"
          offset="1"
          id="stop4178-1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient4490">
-      <stop
-         style="stop-color:#434343;stop-opacity:1;"
-         offset="0"
-         id="stop4492" />
-      <stop
-         style="stop-color:#5e5e5e;stop-opacity:1;"
-         offset="1"
-         id="stop4494" />
     </linearGradient>
     <radialGradient
        inkscape:collect="always"
@@ -568,73 +248,61 @@
      sodipodi:nodetypes="ssccscsscsscsssscccss"
      inkscape:connector-curvature="0"
      id="path3816"
-     d="m 21.53125,14 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 18.5,18 15.46875,18 c -0.957,0 -1.7615,0.34 -2.4375,1 C 12.35125,19.664 12,20.47325 12,21.40625 L 12,32.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 38,21.40625 C 38,20.47225 37.676,19.664 37,19 36.324,18.336 35.48825,18 34.53125,18 L 31.5,18 30.8125,15.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 29.418,14.15575 28.94475,14 28.46875,14 z"
+     d="m 21.53125,13 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 18.5,17 15.46875,17 c -0.957,0 -1.7615,0.34 -2.4375,1 C 12.35125,18.664 12,19.47325 12,20.40625 L 12,31.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 38,20.40625 C 38,19.47225 37.676,18.664 37,18 36.324,17.336 35.48825,17 34.53125,17 L 31.5,17 30.8125,14.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 29.418,13.15575 28.94475,13 28.46875,13 Z"
      style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none" />
-  <path
-     style="fill:#373737;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 20.53125,13 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 17.5,17 14.46875,17 c -0.957,0 -1.7615,0.34 -2.4375,1 C 11.35125,18.664 11,19.47325 11,20.40625 L 11,31.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 37,20.40625 C 37,19.47225 36.676,18.664 36,18 35.324,17.336 34.48825,17 33.53125,17 L 30.5,17 29.8125,14.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 28.418,13.15575 27.94475,13 27.46875,13 z"
-     id="path55"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ssccscsscsscsssscccss" />
-  <path
-     style="fill:#000000;fill-opacity:0.0996016;fill-rule:nonzero;stroke:none"
-     inkscape:connector-curvature="0"
-     id="path4041"
-     d="m 33,26 c 0,4.417143 -3.582857,8 -8,8 -4.417143,0 -8,-3.582857 -8,-8 0,-4.417144 3.582857,-8.000001 8,-8.000001 4.417143,0 8,3.582857 8,8.000001 m 0,0" />
-  <path
-     d="m 32,25 c 0,4.417143 -3.582857,8 -8,8 -4.417143,0 -8,-3.582857 -8,-8 0,-4.417144 3.582857,-8.000001 8,-8.000001 4.417143,0 8,3.582857 8,8.000001 m 0,0"
-     id="path81"
-     inkscape:connector-curvature="0"
-     style="fill:#373737;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  <path
-     d="M 31,24.999999 C 31,28.865273 27.865273,32 24.000001,32 20.134728,32 17,28.865273 17,24.999999 c 0,-3.865273 3.134728,-7 7.000001,-7 3.865272,0 6.999999,3.134727 6.999999,7 m 0,0"
-     id="path83"
-     inkscape:connector-curvature="0"
-     style="fill:#233d4b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  <path
-     d="m 28,25 c 0,2.209 -1.791,4 -4,4 -2.209,0 -4,-1.791 -4,-4 0,-2.209001 1.791,-4.000001 4,-4.000001 2.209,0 4,1.791 4,4.000001 m 0,0"
-     id="path85"
-     inkscape:connector-curvature="0"
-     style="fill:#4c6074;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  <path
-     style="fill:url(#radialGradient4040);fill-opacity:1;fill-rule:nonzero;stroke:none"
-     d="m 23.9,28.8 c -1.656854,0 -3,0.745781 -3,1.673846 0,0.442062 0.302904,0.84871 0.801136,1.148718 C 22.420846,31.863928 23.195772,32 24.002273,32 24.618176,32 25.223687,31.91444 25.792046,31.770256 26.458787,31.462044 26.9,30.995883 26.9,30.473846 26.9,29.545781 25.556854,28.8 23.9,28.8 z"
-     id="path4091"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="sscscss" />
-  <path
-     d="m 27,25 c 0,1.6565 -1.344,3 -3,3 -1.6565,0 -3,-1.344 -3,-3 0,-1.6565 1.344,-3.000001 3,-3.000001 1.6565,0 3,1.344001 3,3.000001 m 0,0"
-     id="path87"
-     inkscape:connector-curvature="0"
-     style="fill:#233d4b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  <path
-     d="m 25.5,23.25 c 0,0.690626 -0.559376,1.25 -1.25,1.25 -0.690626,0 -1.25,-0.559374 -1.25,-1.25 0,-0.690626 0.559374,-1.250001 1.25,-1.250001 0.690624,0 1.25,0.559375 1.25,1.250001 m 0,0"
-     id="path89"
-     style="fill:url(#radialGradient4037);fill-rule:nonzero;stroke:none"
-     inkscape:connector-curvature="0" />
-  <path
-     d="M 24.5,26.250001 C 24.5,26.663251 24.163251,27 23.750001,27 23.336751,27 23,26.663251 23,26.250001 23,25.836751 23.336751,25.5 23.750001,25.5 24.163251,25.5 24.5,25.836751 24.5,26.250001 m 0,0"
-     id="path91"
-     style="fill:url(#radialGradient4039);fill-rule:nonzero;stroke:none"
-     inkscape:connector-curvature="0" />
-  <path
-     transform="matrix(0.37348354,0,0,0.30701029,14.858798,12.014937)"
-     d="m 30.187501,33.305279 a 5.7119875,3.2572198 0 1 1 -11.423975,0 5.7119875,3.2572198 0 1 1 11.423975,0 z"
-     sodipodi:ry="3.2572198"
-     sodipodi:rx="5.7119875"
-     sodipodi:cy="33.305279"
-     sodipodi:cx="24.475513"
-     id="path4168"
-     style="fill:#396c61;fill-opacity:0.58565736;fill-rule:nonzero;stroke:none"
-     sodipodi:type="arc" />
-  <path
-     sodipodi:type="arc"
-     style="fill:url(#linearGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none"
-     id="path4172"
-     sodipodi:cx="24.475513"
-     sodipodi:cy="33.305279"
-     sodipodi:rx="5.7119875"
-     sodipodi:ry="3.2572198"
-     d="m 30.187501,33.305279 a 5.7119875,3.2572198 0 1 1 -11.423975,0 5.7119875,3.2572198 0 1 1 11.423975,0 z"
-     transform="matrix(0.46685441,0,0,0.34385152,12.573498,9.2279295)" />
+  <g
+     id="g4247"
+     transform="translate(0,-1)">
+    <path
+       sodipodi:nodetypes="ssccscsscsscsssscccss"
+       inkscape:connector-curvature="0"
+       id="path55"
+       d="m 20.53125,13 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 17.5,17 14.46875,17 c -0.957,0 -1.7615,0.34 -2.4375,1 C 11.35125,18.664 11,19.47325 11,20.40625 L 11,31.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 37,20.40625 C 37,19.47225 36.676,18.664 36,18 35.324,17.336 34.48825,17 33.53125,17 L 30.5,17 29.8125,14.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 28.418,13.15575 27.94475,13 27.46875,13 Z"
+       style="fill:#484848;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       d="m 33,26 c 0,4.417143 -3.582857,8 -8,8 -4.417143,0 -8,-3.582857 -8,-8 0,-4.417144 3.582857,-8.000001 8,-8.000001 4.417143,0 8,3.582857 8,8.000001 m 0,0"
+       id="path4041"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:0.0996016;fill-rule:nonzero;stroke:none" />
+    <path
+       style="fill:#2f4f61;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       id="path83"
+       d="M 31.999999,24.999999 C 31.999999,29.417455 28.417454,33 24.000001,33 19.582546,33 16,29.417455 16,24.999999 16,20.582545 19.582546,17 24.000001,17 c 4.417453,0 7.999998,3.582545 7.999998,7.999999 m 0,0" />
+    <path
+       id="path85"
+       d="m 24,20 c -2.76125,0 -5,2.238749 -5,5 0,2.76125 2.23875,5 5,5 2.76125,0 5,-2.23875 5,-5 0,-2.761251 -2.23875,-5 -5,-5 z m 0,1 c 2.208667,0 4,1.792 4,4 0,2.208667 -1.792,4 -4,4 -2.208667,0 -4,-1.792 -4,-4 0,-2.208667 1.792,-4 4,-4 z"
+       style="fill:#53687d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="sscscss"
+       inkscape:connector-curvature="0"
+       id="path4091"
+       d="m 24,29.06667 c -1.932994,0 -3.5,0.870071 -3.5,1.952816 0,0.515742 0.353384,0.99016 0.934656,1.340168 0.83966,0.281594 1.743746,0.440346 2.684667,0.440346 0.718553,0 1.424974,-0.09986 2.088063,-0.268034 C 26.985247,32.172384 27.5,31.628533 27.5,31.019486 27.5,29.936741 25.932994,29.06667 24,29.06667 Z"
+       style="fill:url(#radialGradient4040);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient4037);fill-rule:nonzero;stroke:none"
+       id="path89"
+       d="m 25.5,23.25 c 0,0.690626 -0.559376,1.25 -1.25,1.25 -0.690626,0 -1.25,-0.559374 -1.25,-1.25 0,-0.690626 0.559374,-1.250001 1.25,-1.250001 0.690624,0 1.25,0.559375 1.25,1.250001 m 0,0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:url(#radialGradient4039);fill-rule:nonzero;stroke:none"
+       id="path91"
+       d="M 24.5,26.250001 C 24.5,26.663251 24.163251,27 23.750001,27 23.336751,27 23,26.663251 23,26.250001 23,25.836751 23.336751,25.5 23.750001,25.5 24.163251,25.5 24.5,25.836751 24.5,26.250001 m 0,0" />
+    <ellipse
+       ry="1"
+       rx="2.1333332"
+       cy="21.34"
+       cx="24"
+       style="fill:#3d7569;fill-opacity:0.58565734;fill-rule:nonzero;stroke:none"
+       id="path4168" />
+    <ellipse
+       ry="1.12"
+       rx="2.6666665"
+       cy="19.780001"
+       cx="24"
+       id="path4172"
+       style="fill:url(#linearGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
 </svg>

--- a/Numix-Circle/48x48/apps/digikam.svg
+++ b/Numix-Circle/48x48/apps/digikam.svg
@@ -1,1 +1,640 @@
-accessories-camera.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="digikam4.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/icons.png"
+   inkscape:export-xdpi="245"
+   inkscape:export-ydpi="245">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:snap-bbox="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:snap-midpoints="false"
+     inkscape:snap-grids="true"
+     inkscape:zoom="16"
+     inkscape:cx="24.798075"
+     inkscape:cy="24.782662"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3038"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient6121">
+      <stop
+         style="stop-color:#cc5f50;stop-opacity:1;"
+         offset="0"
+         id="stop6123" />
+      <stop
+         style="stop-color:#d57a6e;stop-opacity:1;"
+         offset="1"
+         id="stop6125" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4393">
+      <stop
+         style="stop-color:#7d683e;stop-opacity:1;"
+         offset="0"
+         id="stop4395" />
+      <stop
+         style="stop-color:#7a6841;stop-opacity:1;"
+         offset="1"
+         id="stop4397" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4080">
+      <stop
+         id="stop4082"
+         offset="0"
+         style="stop-color:#156aa3;stop-opacity:1;" />
+      <stop
+         id="stop4084"
+         offset="1"
+         style="stop-color:#1a7cbe;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4072">
+      <stop
+         style="stop-color:#ffff00;stop-opacity:1;"
+         offset="0"
+         id="stop4074" />
+      <stop
+         style="stop-color:#ffff00;stop-opacity:0;"
+         offset="1"
+         id="stop4076" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3977">
+      <stop
+         style="stop-color:#ef6651;stop-opacity:1;"
+         offset="0"
+         id="stop3979" />
+      <stop
+         style="stop-color:#f17b69;stop-opacity:1;"
+         offset="1"
+         id="stop3981" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3936">
+      <stop
+         id="stop3938"
+         offset="0"
+         style="stop-color:#5880ff;stop-opacity:1;" />
+      <stop
+         id="stop3940"
+         offset="1"
+         style="stop-color:#9ab2ff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3827">
+      <stop
+         style="stop-color:#3f3953;stop-opacity:1;"
+         offset="0"
+         id="stop3829" />
+      <stop
+         style="stop-color:#766b99;stop-opacity:1;"
+         offset="1"
+         id="stop3831" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3817">
+      <stop
+         id="stop3819"
+         offset="0"
+         style="stop-color:#655b85;stop-opacity:1;" />
+      <stop
+         id="stop3821"
+         offset="1"
+         style="stop-color:#3f3953;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3784">
+      <stop
+         style="stop-color:#655b85;stop-opacity:1;"
+         offset="0"
+         id="stop3786" />
+      <stop
+         style="stop-color:#3f3953;stop-opacity:1;"
+         offset="1"
+         id="stop3788" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3040">
+      <stop
+         style="stop-color:#f06758;stop-opacity:1;"
+         offset="0"
+         id="stop3042" />
+      <stop
+         style="stop-color:#ee5646;stop-opacity:1;"
+         offset="1"
+         id="stop3044" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#333"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#3d3d3d"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-799970715">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-808101755">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3040"
+       id="linearGradient3046"
+       x1="24"
+       y1="1"
+       x2="24"
+       y2="47"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3790"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3793"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3795"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3797"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3800"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientTransform="translate(46,2)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3803"
+       gradientUnits="userSpaceOnUse"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699"
+       gradientTransform="translate(41,0)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3784"
+       id="linearGradient3806"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(41,0)"
+       x1="-34.270798"
+       y1="9.1876106"
+       x2="-10.895576"
+       y2="33.97699" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3827"
+       id="linearGradient3833"
+       x1="35.021236"
+       y1="36.603539"
+       x2="12.061947"
+       y2="11.148674"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-283144270">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-4">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-9" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-295805906">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-9">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-8" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-070777050">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3085">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3087" />
+      </g>
+    </clipPath>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3808"
+       id="radialGradient3814"
+       cx="23.00012"
+       cy="23.993263"
+       fx="23.00012"
+       fy="23.993263"
+       r="12.000658"
+       gradientTransform="matrix(1,0,0,0.99987541,0,0.0029893)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3808">
+      <stop
+         style="stop-color:#ff5858;stop-opacity:1;"
+         offset="0"
+         id="stop3810" />
+      <stop
+         style="stop-color:#ff8c8c;stop-opacity:1;"
+         offset="1"
+         id="stop3812" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4393"
+       id="radialGradient4399"
+       cx="16.652831"
+       cy="30.075977"
+       fx="16.652831"
+       fy="30.075977"
+       r="1.2092668"
+       gradientTransform="matrix(1,0,0,0.92253912,0.47243548,2.9465604)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient6121"
+       id="radialGradient6127"
+       cx="17"
+       cy="17"
+       fx="17"
+       fy="17"
+       r="3.4999998"
+       gradientTransform="matrix(0.85714285,0,0,0.85714285,2.4285718,1.9285676)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       r="5.7119875"
+       fy="33.305279"
+       fx="24.475513"
+       cy="33.305279"
+       cx="24.475513"
+       gradientTransform="matrix(0.52521128,0,0,0.29419011,11.038365,20.679044)"
+       gradientUnits="userSpaceOnUse"
+       id="radialGradient4040"
+       xlink:href="#linearGradient4143-0"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient4143-0">
+      <stop
+         style="stop-color:#284070;stop-opacity:0.78431374;"
+         offset="0"
+         id="stop4145-4" />
+      <stop
+         style="stop-color:#35538b;stop-opacity:0.12941177;"
+         offset="1"
+         id="stop4147-3" />
+    </linearGradient>
+    <radialGradient
+       id="radial1-9"
+       gradientUnits="userSpaceOnUse"
+       cx="6"
+       cy="17.292"
+       r="1"
+       gradientTransform="matrix(0.57142857,0,0,0.57142857,20.571429,16.261697)"
+       xlink:href="#radial0-2" />
+    <radialGradient
+       id="radial0-2"
+       gradientUnits="userSpaceOnUse"
+       cx="6.7729998"
+       cy="5.927"
+       r="0.56400001"
+       gradientTransform="matrix(3.543307,0,0,3.543307,1.47638e-7,3.77575e-4)">
+      <stop
+         stop-color="#8eb0c7"
+         stop-opacity="1"
+         id="stop22-6"
+         offset="0"
+         style="stop-color:#6b98b5;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#8eb0c7"
+         stop-opacity="0"
+         id="stop24-68"
+         style="stop-color:#6a97b6;stop-opacity:0.08474576;" />
+    </radialGradient>
+    <radialGradient
+       id="radialGradient3985"
+       gradientUnits="userSpaceOnUse"
+       cx="6.7729998"
+       cy="5.927"
+       r="0.56400001"
+       gradientTransform="matrix(3.543307,0,0,3.543307,1.47638e-7,3.77575e-4)">
+      <stop
+         stop-color="#8eb0c7"
+         stop-opacity="1"
+         id="stop3987" />
+      <stop
+         offset="1"
+         stop-color="#8eb0c7"
+         stop-opacity="0"
+         id="stop3989"
+         style="stop-color:#81a7c1;stop-opacity:0.03921569;" />
+    </radialGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4174-9"
+       id="linearGradient4180"
+       x1="24.475513"
+       y1="36.93475"
+       x2="24.475513"
+       y2="29.489677"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4174-9">
+      <stop
+         style="stop-color:#205867;stop-opacity:1;"
+         offset="0"
+         id="stop4176-6" />
+      <stop
+         style="stop-color:#2a768a;stop-opacity:0;"
+         offset="1"
+         id="stop4178-1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4490">
+      <stop
+         style="stop-color:#434343;stop-opacity:1;"
+         offset="0"
+         id="stop4492" />
+      <stop
+         style="stop-color:#5e5e5e;stop-opacity:1;"
+         offset="1"
+         id="stop4494" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#radial0-2"
+       id="radialGradient4037"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(2.2145672,0,0,2.2145672,9.2499978,10.125234)"
+       cx="6.7729998"
+       cy="5.927"
+       r="0.56400001" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#radial0-2"
+       id="radialGradient4039"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.75000009,0,0,0.75000009,19.250001,13.280977)"
+       cx="6"
+       cy="17.292"
+       r="1" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill:#ffeeaa">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3046);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     id="g4177">
+    <g
+       id="g4125">
+      <g
+         id="g3840"
+         transform="matrix(0.68178719,0,0,0.69230773,8.0467251,13.153845)" />
+      <g
+         transform="matrix(0.42306065,0,0,0.42309478,19.346756,10.768588)"
+         id="g3127">
+        <g
+           clip-path="url(#clipPath-070777050)"
+           id="g3129">
+          <!-- color: #7ec1ee -->
+          <g
+             id="g3131" />
+        </g>
+      </g>
+      <g
+         id="g4111"
+         transform="translate(0,1)">
+        <g
+           id="g4107" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g6199" />
+  <path
+     sodipodi:nodetypes="ssccscsscsscsssscccss"
+     inkscape:connector-curvature="0"
+     id="path3816"
+     d="m 21.53125,14 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 18.5,18 15.46875,18 c -0.957,0 -1.7615,0.34 -2.4375,1 C 12.35125,19.664 12,20.47325 12,21.40625 L 12,32.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 38,21.40625 C 38,20.47225 37.676,19.664 37,19 36.324,18.336 35.48825,18 34.53125,18 L 31.5,18 30.8125,15.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 29.418,14.15575 28.94475,14 28.46875,14 z"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none" />
+  <path
+     style="fill:#373737;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 20.53125,13 c -0.48,0 -0.94925,0.15575 -1.40625,0.46875 -0.457,0.313 -0.7625,0.699 -0.9375,1.125 L 17.5,17 14.46875,17 c -0.957,0 -1.7615,0.34 -2.4375,1 C 11.35125,18.664 11,19.47325 11,20.40625 L 11,31.625 c 0,0.934 0.35225,1.715 1.03125,2.375 0.676,0.66 1.4795,1 2.4375,1 l 19.0625,0 c 0.957,0 1.79275,-0.344 2.46875,-1 0.676,-0.664 1,-1.445 1,-2.375 L 37,20.40625 C 37,19.47225 36.676,18.664 36,18 35.324,17.336 34.48825,17 33.53125,17 L 30.5,17 29.8125,14.59375 c -0.168,-0.43 -0.4795,-0.809 -0.9375,-1.125 C 28.418,13.15575 27.94475,13 27.46875,13 z"
+     id="path55"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssccscsscsscsssscccss" />
+  <path
+     style="fill:#000000;fill-opacity:0.0996016;fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0"
+     id="path4041"
+     d="m 33,26 c 0,4.417143 -3.582857,8 -8,8 -4.417143,0 -8,-3.582857 -8,-8 0,-4.417144 3.582857,-8.000001 8,-8.000001 4.417143,0 8,3.582857 8,8.000001 m 0,0" />
+  <path
+     d="m 32,25 c 0,4.417143 -3.582857,8 -8,8 -4.417143,0 -8,-3.582857 -8,-8 0,-4.417144 3.582857,-8.000001 8,-8.000001 4.417143,0 8,3.582857 8,8.000001 m 0,0"
+     id="path81"
+     inkscape:connector-curvature="0"
+     style="fill:#373737;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     d="M 31,24.999999 C 31,28.865273 27.865273,32 24.000001,32 20.134728,32 17,28.865273 17,24.999999 c 0,-3.865273 3.134728,-7 7.000001,-7 3.865272,0 6.999999,3.134727 6.999999,7 m 0,0"
+     id="path83"
+     inkscape:connector-curvature="0"
+     style="fill:#233d4b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     d="m 28,25 c 0,2.209 -1.791,4 -4,4 -2.209,0 -4,-1.791 -4,-4 0,-2.209001 1.791,-4.000001 4,-4.000001 2.209,0 4,1.791 4,4.000001 m 0,0"
+     id="path85"
+     inkscape:connector-curvature="0"
+     style="fill:#4c6074;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     style="fill:url(#radialGradient4040);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 23.9,28.8 c -1.656854,0 -3,0.745781 -3,1.673846 0,0.442062 0.302904,0.84871 0.801136,1.148718 C 22.420846,31.863928 23.195772,32 24.002273,32 24.618176,32 25.223687,31.91444 25.792046,31.770256 26.458787,31.462044 26.9,30.995883 26.9,30.473846 26.9,29.545781 25.556854,28.8 23.9,28.8 z"
+     id="path4091"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sscscss" />
+  <path
+     d="m 27,25 c 0,1.6565 -1.344,3 -3,3 -1.6565,0 -3,-1.344 -3,-3 0,-1.6565 1.344,-3.000001 3,-3.000001 1.6565,0 3,1.344001 3,3.000001 m 0,0"
+     id="path87"
+     inkscape:connector-curvature="0"
+     style="fill:#233d4b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <path
+     d="m 25.5,23.25 c 0,0.690626 -0.559376,1.25 -1.25,1.25 -0.690626,0 -1.25,-0.559374 -1.25,-1.25 0,-0.690626 0.559374,-1.250001 1.25,-1.250001 0.690624,0 1.25,0.559375 1.25,1.250001 m 0,0"
+     id="path89"
+     style="fill:url(#radialGradient4037);fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0" />
+  <path
+     d="M 24.5,26.250001 C 24.5,26.663251 24.163251,27 23.750001,27 23.336751,27 23,26.663251 23,26.250001 23,25.836751 23.336751,25.5 23.750001,25.5 24.163251,25.5 24.5,25.836751 24.5,26.250001 m 0,0"
+     id="path91"
+     style="fill:url(#radialGradient4039);fill-rule:nonzero;stroke:none"
+     inkscape:connector-curvature="0" />
+  <path
+     transform="matrix(0.37348354,0,0,0.30701029,14.858798,12.014937)"
+     d="m 30.187501,33.305279 a 5.7119875,3.2572198 0 1 1 -11.423975,0 5.7119875,3.2572198 0 1 1 11.423975,0 z"
+     sodipodi:ry="3.2572198"
+     sodipodi:rx="5.7119875"
+     sodipodi:cy="33.305279"
+     sodipodi:cx="24.475513"
+     id="path4168"
+     style="fill:#396c61;fill-opacity:0.58565736;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc" />
+  <path
+     sodipodi:type="arc"
+     style="fill:url(#linearGradient4180);fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path4172"
+     sodipodi:cx="24.475513"
+     sodipodi:cy="33.305279"
+     sodipodi:rx="5.7119875"
+     sodipodi:ry="3.2572198"
+     d="m 30.187501,33.305279 a 5.7119875,3.2572198 0 1 1 -11.423975,0 5.7119875,3.2572198 0 1 1 11.423975,0 z"
+     transform="matrix(0.46685441,0,0,0.34385152,12.573498,9.2279295)" />
+</svg>


### PR DESCRIPTION
Made this icon for digiKam:
![digikam](https://cloud.githubusercontent.com/assets/7050624/5888932/f35d0820-a410-11e4-9deb-f1d627d4d3b2.png)

Replaces the current icon (symlink) which is also used for several screenshot/camera apps:
![digikam_alt](https://cloud.githubusercontent.com/assets/7050624/5888935/14701bba-a411-11e4-84f0-40ad55696466.png)

