### PR TITLE
Icon for CuteMarkEd. Fixes #1490

### DIFF
--- a/Numix-Circle/48x48/apps/cutemarked.svg
+++ b/Numix-Circle/48x48/apps/cutemarked.svg
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="cutemarked1c.svg">
+  <metadata
+     id="metadata77">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview75"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="8"
+     inkscape:cx="19.423986"
+     inkscape:cy="26.972788"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3054" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#cb3131"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#d14040"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-533888948">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-543229327">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g71">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path73" />
+  </g>
+  <g
+     id="g3940">
+    <path
+       style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none"
+       d="m 16,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 L 15,14 c -1.108,0 -2,0.892 -2,2 l 0,18 c 0,1.108 0.892,2 2,2 l 20,0 c 1.108,0 2,-0.892 2,-2 l 0,-18 c 0,-1.108 -0.892,-2 -2,-2 l -0.0625,0 C 34.823884,13.429915 34.4643,13 34,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 31.823884,13.429915 31.4643,13 31,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 28.823884,13.429915 28.4643,13 28,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 25.823884,13.429915 25.4643,13 25,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 22.823884,13.429915 22.4643,13 22,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 19.823884,13.429915 19.4643,13 19,13 c -0.4643,0 -0.823884,0.429915 -0.9375,1 l -1.125,0 C 16.823884,13.429915 16.4643,13 16,13 z"
+       id="rect3103"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="scsccssccscsccsccsccsccsccsccs" />
+    <rect
+       rx="2"
+       ry="2"
+       y="15"
+       x="12"
+       height="20"
+       width="24"
+       id="rect3854"
+       style="fill:#aeb4c2;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#c4cad7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3852"
+       width="24"
+       height="20"
+       x="12"
+       y="14"
+       ry="2"
+       rx="2" />
+    <rect
+       rx="2"
+       ry="2"
+       y="13"
+       x="12"
+       height="20"
+       width="24"
+       id="rect3850"
+       style="fill:#deece6;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect3056"
+       d="m 14,19 0,10 3,0 0,-6 3,4 3,-4 0,6 3,0 0,-10 -3,0 -3,4 -3,-4 -3,0 z m 15,0 0,6 -2,0 3.5,4 3.5,-4 -2,0 0,-6 -3,0 z"
+       style="fill:#2d2d2d;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       ry="1.3333334"
+       rx="1"
+       y="12"
+       x="14"
+       height="4"
+       width="2"
+       id="rect3856"
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3858"
+       width="2"
+       height="4"
+       x="17"
+       y="12"
+       rx="1"
+       ry="1.3333334" />
+    <rect
+       ry="1.3333334"
+       rx="1"
+       y="12"
+       x="20"
+       height="4"
+       width="2"
+       id="rect3860"
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3862"
+       width="2"
+       height="4"
+       x="23"
+       y="12"
+       rx="1"
+       ry="1.3333334" />
+    <rect
+       ry="1.3333334"
+       rx="1"
+       y="12"
+       x="26"
+       height="4"
+       width="2"
+       id="rect3864"
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3866"
+       width="2"
+       height="4"
+       x="29"
+       y="12"
+       rx="1"
+       ry="1.3333334" />
+    <rect
+       ry="1.3333334"
+       rx="1"
+       y="12"
+       x="32"
+       height="4"
+       width="2"
+       id="rect3868"
+       style="fill:#999999;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for CuteMarkEd, issue #1490

Pushed icon:
![cutemarked3](https://cloud.githubusercontent.com/assets/7050624/5928358/e4dbf682-a67a-11e4-83b3-f67d85550cfb.png)

Alternatives:
![cutemarked2b](https://cloud.githubusercontent.com/assets/7050624/5928364/f6197c1c-a67a-11e4-8098-4ca2d0623a04.png)
![cutemarked1c](https://cloud.githubusercontent.com/assets/7050624/5928367/fb53e424-a67a-11e4-8cb4-8babaeed563d.png)

