### PR TITLE
Symlink for qdbusviewer. Fixes #1491

### DIFF
--- a/Numix-Circle/48x48/apps/qdbusviewer.svg
+++ b/Numix-Circle/48x48/apps/qdbusviewer.svg
@@ -1,0 +1,1 @@
+qtdbusviewer.svg


### PR DESCRIPTION
Made a symlink instead of entirely deleting *qtdbusviewer.svg* for as far as I can see its long name is actually "Qt D-Bus Viewer". Maybe the icon is called accordingly somewhere.
http://qt-project.org/doc/qt-4.8/qdbusviewer.html