### PR TITLE
Icon for Translator. Fixes #1465

### DIFF
--- a/Numix-Circle/48x48/apps/translator.svg
+++ b/Numix-Circle/48x48/apps/translator.svg
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg3060"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="translator1.svg">
+  <metadata
+     id="metadata3150">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview3148"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="27.179236"
+     inkscape:cy="21.234146"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3060">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3807" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3062">
+    <linearGradient
+       id="linearGradient3902">
+      <stop
+         style="stop-color:#4eabea;stop-opacity:1;"
+         offset="0"
+         id="stop3904" />
+      <stop
+         style="stop-color:#60b3ec;stop-opacity:1;"
+         offset="1"
+         id="stop3906" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#3d5f89"
+         stop-opacity="1"
+         id="stop3065" />
+      <stop
+         offset="1"
+         stop-color="#436896"
+         stop-opacity="1"
+         id="stop3067" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-884139982">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3070">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path3072" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-893908360">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3075">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path3077" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linear0"
+       gradientUnits="userSpaceOnUse"
+       x1="308.56"
+       y1="189.18"
+       x2="304.14"
+       y2="192.71"
+       gradientTransform="matrix(1.341921,0,0,1.376362,-387.47068,-240.73097)">
+      <stop
+         stop-color="#2eb21e"
+         stop-opacity="1"
+         id="stop3080" />
+      <stop
+         offset="0.683"
+         stop-color="#45b227"
+         stop-opacity="1"
+         id="stop3082" />
+      <stop
+         offset="1"
+         stop-color="#70cf16"
+         stop-opacity="0"
+         id="stop3084" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3086"
+       gradientUnits="userSpaceOnUse"
+       x1="308.56"
+       y1="189.18"
+       x2="304.14"
+       y2="192.71"
+       gradientTransform="matrix(1.341921,0,0,1.376362,-387.470683,-240.730967)">
+      <stop
+         stop-color="#2eb21e"
+         stop-opacity="1"
+         id="stop3088" />
+      <stop
+         offset="0.683"
+         stop-color="#45b227"
+         stop-opacity="1"
+         id="stop3090" />
+      <stop
+         offset="1"
+         stop-color="#70cf16"
+         stop-opacity="0"
+         id="stop3092" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3902"
+       id="linearGradient3908"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g3094">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path3096" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path3098" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path3100" />
+  </g>
+  <g
+     id="g3102">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path3104"
+       style="fill:url(#linearGradient3908);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g3106" />
+  <g
+     id="g3108"
+     transform="matrix(1.0000385,0,0,1,-4.6155621e-4,0)">
+    <g
+       clip-path="url(#clipPath-884139982)"
+       id="g3110">
+      <g
+         transform="translate(1,1)"
+         id="g3112">
+        <g
+           id="g3114"
+           style="opacity:0.1">
+          <!-- color: #436896 -->
+          <g
+             id="g3116">
+            <path
+               d="m 30.93,20.15 1.426,0 0,-0.574 0.586,0 0,1.422 -3.129,0 0,-0.887 c 0.441,-0.102 0.781,-0.383 1.012,-0.848 0.227,-0.469 0.344,-1.109 0.344,-1.926 0,-0.906 -0.141,-1.594 -0.426,-2.07 -0.289,-0.473 -0.703,-0.715 -1.25,-0.715 -0.547,0 -0.961,0.238 -1.25,0.715 -0.281,0.473 -0.422,1.168 -0.422,2.078 0,0.801 0.117,1.438 0.348,1.914 0.23,0.469 0.566,0.75 1,0.852 l 0,0.887 -3.137,0 0,-1.422 0.582,0 0,0.574 1.43,0 C 27.368,19.869 26.86,19.482 26.513,18.99 26.165,18.494 25.99,17.912 25.99,17.236 c 0,-0.969 0.316,-1.75 0.957,-2.34 0.645,-0.598 1.484,-0.895 2.539,-0.895 1.055,0 1.898,0.301 2.543,0.895 0.645,0.59 0.961,1.371 0.961,2.34 0,0.676 -0.172,1.262 -0.52,1.754 -0.348,0.492 -0.855,0.879 -1.535,1.16"
+               id="path3120"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     transform="matrix(1.0000385,0,0,1,0.99957654,0)"
+     id="g3874"
+     style="fill:#1a1a1a">
+    <g
+       id="g3876"
+       clip-path="url(#clipPath-893908360)"
+       style="fill:#1a1a1a">
+      <!-- color: #436896 -->
+      <g
+         id="g3878"
+         style="fill:#1a1a1a">
+        <path
+           style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none"
+           d="M 25 12 L 25 18.9375 C 23.629814 17.751331 21.678065 17 19.5 17 C 18.915409 17 18.358613 17.05502 17.8125 17.15625 L 14 14 L 14.625 18.4375 C 13.013208 19.538003 12 21.171912 12 23 C 12 26.181042 15.087942 28.765433 19 28.96875 C 18.99966 28.979527 19 28.989137 19 29 L 19 32 L 13 36 L 19 36 L 19 37 C 19 37.554 19.446 38 20 38 L 31 38 C 31.554 38 32 37.554 32 37 L 32 29 C 32 28.446 31.554 28 31 28 L 23.625 28 C 25.324972 27.100139 26.52588 25.673538 26.875 24 L 32 24 L 36 32 L 36 24 L 38 24 L 38 12 L 25 12 z "
+           transform="matrix(0.9999615,0,0,1,-0.99953806,0)"
+           id="path3880" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g3128"
+     transform="matrix(1.0000385,0,0,1,-4.244615e-4,-1)">
+    <g
+       clip-path="url(#clipPath-893908360)"
+       id="g3130">
+      <!-- color: #436896 -->
+      <g
+         id="g3132">
+        <path
+           d="m 23.999499,12 12.999501,0 0,12 -1.999924,0 0,8 -3.999846,-8 -6.999731,0"
+           id="path3134"
+           inkscape:connector-curvature="0"
+           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:nodetypes="ccccccc" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g3144">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path3146" />
+  </g>
+  <g
+     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Sazanami Gothic;-inkscape-font-specification:Sazanami Gothic Medium"
+     id="text3025"
+     transform="matrix(0.99964103,0,0,0.99445819,1.0118446,-0.909157)">
+    <path
+       style="font-size:medium;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;text-indent:0;text-align:start;text-decoration:none;line-height:125%;letter-spacing:0;word-spacing:0;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;text-anchor:start;baseline-shift:baseline;color:#000000;fill:#535353;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.2;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;font-family:Sazanami Gothic;-inkscape-font-specification:Sazanami Gothic Bold"
+       d="m 27.8125,14.0625 c 0.04346,0.377254 -0.0076,0.76175 -0.03125,1.09375 -0.583457,0.05514 -1.10634,0.02962 -1.617187,0.05469 -0.01413,0.354199 0.03402,0.607112 0.05469,0.945312 l 0.09375,0 c 0.520987,-0.02252 0.990362,-0.06591 1.4375,-0.09375 -0.0186,0.40655 -0.03523,0.837004 -0.03125,1.34375 C 27.405202,17.561313 27.123558,17.768653 26.875,18 c -0.267507,0.248986 -0.489044,0.548302 -0.65625,0.90625 -0.163711,0.356711 -0.236097,0.760298 -0.21875,1.1875 0.01735,0.420868 0.09203,0.745196 0.28125,1 0.52117,0.638587 1.050477,0.552626 1.6875,0.3125 0.217845,-0.111521 0.36517,-0.188003 0.5,-0.28125 0.05055,0.0874 0.06254,0.187616 0.09375,0.28125 l 0.09375,-0.0625 C 28.904013,21.146308 29.232266,21.062757 29.5,20.9375 l 0.03125,-0.09375 c 0.0064,-0.203165 -0.146588,-0.376941 -0.21875,-0.5625 0.296624,-0.382052 0.534174,-0.761124 0.71875,-1.15625 0.179077,-0.389005 0.35557,-0.809388 0.5,-1.25 0.169011,0.03292 0.371109,0.07006 0.59375,0.15625 0.753774,0.367357 0.834896,0.788626 0.84375,1.34375 -0.01567,0.27942 -0.09734,0.525023 -0.28125,0.75 -0.507903,0.537027 -1.144843,0.678967 -1.8125,0.8125 l -0.09375,0.03125 c 0.02958,0.403875 0.244609,0.727927 0.40625,1.0625 0.476438,-0.108668 0.949811,-0.297608 1.3125,-0.46875 1.01639,-0.482884 1.448511,-1.164213 1.5,-2.21875 -0.0088,-1.045698 -0.449452,-1.595638 -1.375,-2.0625 -0.349765,-0.135639 -0.620352,-0.195947 -0.84375,-0.25 0.01561,-0.16616 0.130895,-0.283605 0.1875,-0.40625 0.04352,-0.04658 0.07922,-0.08019 0.0625,-0.15625 -0.01672,-0.07606 -0.06524,-0.136253 -0.125,-0.15625 L 30.125,16.15625 c -0.08697,-0.02496 -0.166734,0.0203 -0.21875,0.0625 -0.08046,0.211589 -0.06204,0.454977 -0.09375,0.6875 -0.462236,0.02914 -0.850983,0.09828 -1.1875,0.1875 0.0026,-0.301471 0.0053,-0.666146 0.03125,-1.09375 0.157761,-0.01807 0.401694,-0.05478 0.8125,-0.09375 0.651532,-0.08364 1.20412,-0.170208 1.75,-0.25 -0.07918,-0.317808 -0.159128,-0.635429 -0.23875,-0.953125 -0.784657,0.177297 -1.58442,0.324006 -2.253437,0.40625 -0.0076,-0.365935 0.126255,-0.597818 0.210937,-0.890625 -0.0235,-0.07547 -0.09764,-0.10931 -0.15625,-0.125 L 28,14 c -0.07892,-0.04091 -0.143033,0.02164 -0.1875,0.0625 z m 1.71875,3.75 c -0.132142,0.544057 -0.394875,1.009216 -0.625,1.46875 -0.153797,-0.419266 -0.194635,-0.885992 -0.25,-1.28125 0.33875,-0.09785 0.624645,-0.161452 0.875,-0.1875 z m -1.75,0.59375 c 0.02746,0.26185 0.07796,0.519479 0.125,0.78125 0.059,0.298538 0.136161,0.628432 0.25,1 -0.222404,0.258967 -0.51685,0.378737 -0.8125,0.40625 -0.181012,0.01076 -0.282242,-0.03722 -0.34375,-0.125 -0.09729,-0.186696 -0.08555,-0.370221 -0.09375,-0.53125 0.0088,-0.245894 0.05897,-0.494055 0.15625,-0.71875 0.145235,-0.394321 0.454813,-0.558589 0.71875,-0.8125 z"
+       id="path3803"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccscccccccccccccccccccccccscccccccccccccccccccccccccc" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     d="M 24,18.21875 24,23 l 3,0 c 0,-1.961069 -1.181357,-3.686408 -3,-4.78125 z"
+     id="path3134-9" />
+  <path
+     style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="M 13 13 L 13.625 17.4375 C 12.013208 18.538003 11 20.171912 11 22 C 11 25.313709 14.357864 28 18.5 28 C 22.642136 28 26 25.313709 26 22 C 26 18.686291 22.642136 16 18.5 16 C 17.915409 16 17.358613 16.055024 16.8125 16.15625 L 13 13 z "
+     id="path3138" />
+  <path
+     style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 19,27 c -0.554,0 -1,0.446 -1,1 l 0,3 -6,4 6,0 0,1 c 0,0.554 0.446,1 1,1 l 11,0 c 0.554,0 1,-0.446 1,-1 l 0,-8 c 0,-0.554 -0.446,-1 -1,-1 z"
+     id="rect3838"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sscccsssssss" />
+  <path
+     d="m 19.75,23.3 -2.5,0 L 16.634582,25 15,25 l 2.634582,-7 1.756587,0 2.6051,7 -1.590061,0 M 18.504135,19.653 17.634582,22 l 1.745629,0"
+     id="path3142"
+     inkscape:connector-curvature="0"
+     style="fill:#535353;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:nodetypes="ccccccccccc" />
+  <text
+     xml:space="preserve"
+     style="font-size:20px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sazanami Gothic;-inkscape-font-specification:Sazanami Gothic Medium"
+     x="14.8125"
+     y="33.25"
+     id="text3834"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan3836"
+       x="14.8125"
+       y="33.25" /></text>
+  <g
+     transform="matrix(0.9649841,0,0,1.0362865,0.22778412,0.54326662)"
+     style="font-size:9.97494984px;font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sazanami Gothic;-inkscape-font-specification:Sazanami Gothic Medium"
+     id="text3840">
+    <path
+       d="m 23.209492,27.460302 c 0.452195,6e-6 0.834568,0.15628 1.147119,0.468822 0.312545,0.312554 0.468819,0.698252 0.468823,1.157094 -4e-6,0.365753 -0.126353,0.691601 -0.379048,0.977545 0.0798,0.03325 0.166245,0.07315 0.259349,0.1197 0.09974,0.04655 0.17622,0.08313 0.229423,0.109724 0.0532,0.01995 0.12302,0.0399 0.209474,0.05985 0.08644,0.01995 0.18287,0.02993 0.289274,0.02992 0.152944,3e-6 0.277077,0.05209 0.503181,-0.02771 l 0,-1.929968 -1.036287,0 0,-0.964984 5.181433,0 0,0.964984 -1.036286,0 0,4.824921 -1.036287,0 0,-4.824921 -1.036287,0 0,4.824921 -1.036286,0 0,-1.83347 c -0.133004,0.03325 -0.217238,0.0535 -0.383482,0.05349 -0.0665,3e-6 -0.139654,-0.0066 -0.219449,-0.01995 0.0066,0.0532 0.01,0.126352 0.01,0.219449 -4e-6,0.551949 -0.152953,0.880765 -0.458847,1.180012 -0.299253,0.299249 -0.728175,0.400469 -1.286769,0.400469 -0.339151,0 -0.684949,-0.0514 -1.037395,-0.250896 -0.352449,-0.199498 -0.655023,-0.435649 -0.90772,-0.708299 -0.413665,-0.442331 -0.677145,-0.868413 -0.887771,-1.419282 l -0.01,-0.119699 0.857846,-0.518697 0.09975,0.179549 c 0.718194,1.236896 1.35659,1.855342 1.91519,1.85534 0.219446,2e-6 0.372395,-0.04322 0.458848,-0.129674 0.0931,-0.0931 0.139645,-0.249372 0.139649,-0.468823 -4e-6,-0.272646 -0.08313,-0.48877 -0.249374,-0.648371 -0.159602,-0.159597 -0.379051,-0.239396 -0.658346,-0.239399 -0.252702,3e-6 -0.418951,0.02328 -0.498748,0.06982 l -0.199499,0.09975 -0.458848,-1.077295 0.299249,0 c 0.119697,4e-6 0.206147,0.0033 0.259349,0.01 0.312546,-0.0066 0.551944,-0.0798 0.718196,-0.219449 0.172896,-0.146295 0.262671,-0.342468 0.269324,-0.588522 -3e-6,-0.172894 -0.0399,-0.295918 -0.1197,-0.369073 -0.07315,-0.07314 -0.202826,-0.113044 -0.389023,-0.119699 -0.4123,5e-6 -0.768073,0.212804 -1.06732,0.638397 l -0.119699,0.179549 -0.837896,-0.628422 0,-0.09975 c 0,-0.219443 0.229423,-0.475467 0.688272,-0.768071 0.465496,-0.299242 0.914368,-0.448866 1.346618,-0.448872"
+       style="font-weight:bold;fill:#535353;fill-opacity:1;-inkscape-font-specification:Sazanami Gothic Bold"
+       id="path3845"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccscssccccccscccccccccccccccscc" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Translator, issue #1465
Pushed:
![translator](https://cloud.githubusercontent.com/assets/7050624/5937513/b104e190-a6f0-11e4-9d4c-570cec12d71f.png)
Alternative background:
![translator1](https://cloud.githubusercontent.com/assets/7050624/5937520/bec59e50-a6f0-11e4-85b2-27f4e1e27248.png)
