### PR TITLE
Icon for Currency + symlink for KEuroCalc. Fixes #1466 , Fixes #1497

### DIFF
--- a/Numix-Circle/48x48/apps/currency.svg
+++ b/Numix-Circle/48x48/apps/currency.svg
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="currency0b.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="2"
+     inkscape:cx="21.92144"
+     inkscape:cy="27.229593"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#78dc23;stop-opacity:1;"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#83df35;stop-opacity:1;"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#f6b22e"
+         stop-opacity="1"
+         id="stop7"
+         offset="0"
+         style="stop-color:#78dc23;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#f7b941"
+         stop-opacity="1"
+         id="stop9"
+         style="stop-color:#83df35;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-159244691">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-171249618">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient4393">
+      <stop
+         style="stop-color:#7d683e;stop-opacity:1;"
+         offset="0"
+         id="stop4395" />
+      <stop
+         style="stop-color:#7a6841;stop-opacity:1;"
+         offset="1"
+         id="stop4397" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6121">
+      <stop
+         style="stop-color:#cc5f50;stop-opacity:1;"
+         offset="0"
+         id="stop6123" />
+      <stop
+         style="stop-color:#d57a6e;stop-opacity:1;"
+         offset="1"
+         id="stop6125" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <rect
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     id="rect3840"
+     width="26"
+     height="20"
+     x="12"
+     y="15" />
+  <g
+     id="g3829"
+     transform="translate(0,-4)">
+    <g
+       transform="matrix(1.1818182,0,0,1.2727273,-4.3636364,-3.6363636)"
+       id="g3890">
+      <rect
+         style="fill:#81786a;fill-opacity:1;stroke:none"
+         id="rect3849"
+         width="22"
+         height="11"
+         x="13"
+         y="17" />
+      <path
+         style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 17,15 -4,4 0,4 4,4 14,0 4,-4 0,-4 -4,-4 z m 3.125,2 c 0.776342,8e-6 1.451117,0.223623 2.03125,0.65625 0.588653,0.425181 0.843744,1.011544 0.84375,1.75 -6e-6,0.402803 -0.07363,0.783295 -0.3125,1.15625 -0.230351,0.365505 -0.681191,0.831894 -1.3125,1.40625 l -1.59375,1.46875 3.21875,0 0,1.5625 -6,0 0,-1.3125 2.625,-2.34375 c 0.528935,-0.469924 0.903182,-0.849005 1.125,-1.125 0.23034,-0.283445 0.343746,-0.551422 0.34375,-0.8125 -4e-6,-0.261066 -0.08504,-0.453432 -0.28125,-0.625 -0.196223,-0.179015 -0.474128,-0.281243 -0.78125,-0.28125 -0.563067,7e-6 -1.090407,0.361341 -1.59375,1.0625 L 17,18.71875 c 0.418031,-0.566893 0.755186,-0.990334 1.25,-1.28125 0.503344,-0.290903 1.107182,-0.437492 1.875,-0.4375 z m 7.375,0 c 1.170697,8e-6 2.043679,0.363467 2.625,1.09375 0.581306,0.722919 0.874993,1.689104 0.875,2.90625 -7e-6,1.209777 -0.293694,2.175961 -0.875,2.90625 C 29.543679,24.629164 28.670697,25 27.5,25 26.329293,25 25.456313,24.629164 24.875,23.90625 24.293684,23.175961 23.999999,22.209777 24,21 c -1e-6,-1.217146 0.293684,-2.183331 0.875,-2.90625 C 25.456313,17.363467 26.329293,17.000008 27.5,17 z m 0,1.4375 c -0.565172,7e-6 -0.983567,0.215399 -1.25,0.6875 -0.266439,0.472112 -0.406252,1.100454 -0.40625,1.875 -2e-6,0.774553 0.139811,1.402896 0.40625,1.875 0.266433,0.472109 0.684828,0.718751 1.25,0.71875 0.565163,1e-6 0.98356,-0.246641 1.25,-0.71875 0.266431,-0.472104 0.406245,-1.100447 0.40625,-1.875 -5e-6,-0.774546 -0.139819,-1.402888 -0.40625,-1.875 -0.26644,-0.472101 -0.684837,-0.687493 -1.25,-0.6875 z"
+         transform="matrix(0.84615383,0,0,0.78571427,3.6923077,5.9999998)"
+         id="rect3851"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccscscccsscssccc" />
+    </g>
+    <rect
+       y="33"
+       x="11"
+       height="1"
+       width="26"
+       id="rect3817"
+       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3819"
+       width="26"
+       height="1"
+       x="11"
+       y="32" />
+    <rect
+       y="36"
+       x="11"
+       height="1"
+       width="26"
+       id="rect3821"
+       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <rect
+       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3823"
+       width="26"
+       height="1"
+       x="11"
+       y="35" />
+    <rect
+       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       id="rect3825"
+       width="26"
+       height="1"
+       x="11"
+       y="34" />
+    <rect
+       y="37"
+       x="11"
+       height="1"
+       width="26"
+       id="rect3827"
+       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+</svg>

--- a/Numix-Circle/48x48/apps/currency.svg
+++ b/Numix-Circle/48x48/apps/currency.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.48.5 r10040"
    width="100%"
    height="100%"
-   sodipodi:docname="currency0b.svg">
+   sodipodi:docname="currency6.svg">
   <metadata
      id="metadata65">
     <rdf:RDF>
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview63"
      showgrid="false"
-     inkscape:zoom="2"
-     inkscape:cx="21.92144"
-     inkscape:cy="27.229593"
+     inkscape:zoom="8"
+     inkscape:cx="21.890003"
+     inkscape:cy="23.391427"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -58,11 +58,11 @@
     <linearGradient
        id="linearGradient3839">
       <stop
-         style="stop-color:#78dc23;stop-opacity:1;"
+         style="stop-color:#aae974;stop-opacity:1;"
          offset="0"
          id="stop3841" />
       <stop
-         style="stop-color:#83df35;stop-opacity:1;"
+         style="stop-color:#b4ec84;stop-opacity:1;"
          offset="1"
          id="stop3843" />
     </linearGradient>
@@ -182,79 +182,174 @@
      transform="scale(1.0060815,0.99395525)"
      style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
      id="text3023" />
-  <rect
-     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
-     id="rect3840"
-     width="26"
-     height="20"
-     x="12"
-     y="15" />
-  <g
-     id="g3829"
-     transform="translate(0,-4)">
-    <g
-       transform="matrix(1.1818182,0,0,1.2727273,-4.3636364,-3.6363636)"
-       id="g3890">
-      <rect
-         style="fill:#81786a;fill-opacity:1;stroke:none"
-         id="rect3849"
-         width="22"
-         height="11"
-         x="13"
-         y="17" />
-      <path
-         style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
-         d="m 17,15 -4,4 0,4 4,4 14,0 4,-4 0,-4 -4,-4 z m 3.125,2 c 0.776342,8e-6 1.451117,0.223623 2.03125,0.65625 0.588653,0.425181 0.843744,1.011544 0.84375,1.75 -6e-6,0.402803 -0.07363,0.783295 -0.3125,1.15625 -0.230351,0.365505 -0.681191,0.831894 -1.3125,1.40625 l -1.59375,1.46875 3.21875,0 0,1.5625 -6,0 0,-1.3125 2.625,-2.34375 c 0.528935,-0.469924 0.903182,-0.849005 1.125,-1.125 0.23034,-0.283445 0.343746,-0.551422 0.34375,-0.8125 -4e-6,-0.261066 -0.08504,-0.453432 -0.28125,-0.625 -0.196223,-0.179015 -0.474128,-0.281243 -0.78125,-0.28125 -0.563067,7e-6 -1.090407,0.361341 -1.59375,1.0625 L 17,18.71875 c 0.418031,-0.566893 0.755186,-0.990334 1.25,-1.28125 0.503344,-0.290903 1.107182,-0.437492 1.875,-0.4375 z m 7.375,0 c 1.170697,8e-6 2.043679,0.363467 2.625,1.09375 0.581306,0.722919 0.874993,1.689104 0.875,2.90625 -7e-6,1.209777 -0.293694,2.175961 -0.875,2.90625 C 29.543679,24.629164 28.670697,25 27.5,25 26.329293,25 25.456313,24.629164 24.875,23.90625 24.293684,23.175961 23.999999,22.209777 24,21 c -1e-6,-1.217146 0.293684,-2.183331 0.875,-2.90625 C 25.456313,17.363467 26.329293,17.000008 27.5,17 z m 0,1.4375 c -0.565172,7e-6 -0.983567,0.215399 -1.25,0.6875 -0.266439,0.472112 -0.406252,1.100454 -0.40625,1.875 -2e-6,0.774553 0.139811,1.402896 0.40625,1.875 0.266433,0.472109 0.684828,0.718751 1.25,0.71875 0.565163,1e-6 0.98356,-0.246641 1.25,-0.71875 0.266431,-0.472104 0.406245,-1.100447 0.40625,-1.875 -5e-6,-0.774546 -0.139819,-1.402888 -0.40625,-1.875 -0.26644,-0.472101 -0.684837,-0.687493 -1.25,-0.6875 z"
-         transform="matrix(0.84615383,0,0,0.78571427,3.6923077,5.9999998)"
-         id="rect3851"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccccccccccccccccccccccccccccccscscccsscssccc" />
-    </g>
-    <rect
-       y="33"
-       x="11"
-       height="1"
-       width="26"
-       id="rect3817"
-       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <rect
-       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="rect3819"
-       width="26"
-       height="1"
-       x="11"
-       y="32" />
-    <rect
-       y="36"
-       x="11"
-       height="1"
-       width="26"
-       id="rect3821"
-       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-    <rect
-       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="rect3823"
-       width="26"
-       height="1"
-       x="11"
-       y="35" />
-    <rect
-       style="fill:#b8d2ac;fill-opacity:1;fill-rule:nonzero;stroke:none"
-       id="rect3825"
-       width="26"
-       height="1"
-       x="11"
-       y="34" />
-    <rect
-       y="37"
-       x="11"
-       height="1"
-       width="26"
-       id="rect3827"
-       style="fill:#81786a;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-  </g>
   <g
      transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
      style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
      id="text3791" />
+  <path
+     transform="matrix(1.3,0,0,1.3,-1,-4.9)"
+     sodipodi:type="arc"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     id="path3911"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z" />
+  <path
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3822"
+     style="fill:#889898;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc"
+     transform="matrix(1.3,0,0,1.3,-2,-5.9)" />
+  <path
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3913"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc"
+     transform="matrix(1.3,0,0,1.3,12,-4.9)" />
+  <path
+     sodipodi:type="arc"
+     style="fill:#c7cfcf;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path3820"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     transform="matrix(1.1,0,0,1.1,1,-2.3)" />
+  <path
+     transform="matrix(1.3,0,0,1.3,-1,8.1)"
+     sodipodi:type="arc"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     id="path3915"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z" />
+  <path
+     transform="matrix(1.3,0,0,1.3,11,-5.9)"
+     sodipodi:type="arc"
+     style="fill:#c09730;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path3824"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z" />
+  <path
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3917"
+     style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc"
+     transform="matrix(1.3,0,0,1.3,12,8.1)" />
+  <path
+     transform="matrix(1.1,0,0,1.1,14,-2.3)"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3826"
+     style="fill:#ebc859;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc" />
+  <path
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3828"
+     style="fill:#7b7146;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc"
+     transform="matrix(1.3,0,0,1.3,-2,7.1)" />
+  <path
+     sodipodi:type="arc"
+     style="fill:#b4a767;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path3830"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     transform="matrix(1.1,0,0,1.1,1,10.7)" />
+  <path
+     transform="matrix(1.3,0,0,1.3,11,7.1)"
+     sodipodi:type="arc"
+     style="fill:#6f6f6f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path3832"
+     sodipodi:cx="15"
+     sodipodi:cy="18"
+     sodipodi:rx="5"
+     sodipodi:ry="5"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z" />
+  <path
+     transform="matrix(1.1,0,0,1.1,14,10.7)"
+     d="m 20,18 a 5,5 0 1 1 -10,0 5,5 0 1 1 10,0 z"
+     sodipodi:ry="5"
+     sodipodi:rx="5"
+     sodipodi:cy="18"
+     sodipodi:cx="15"
+     id="path3834"
+     style="fill:#acafaf;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:type="arc" />
+  <g
+     transform="scale(1.0009181,0.99908276)"
+     style="font-size:24.9317379px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3855">
+    <path
+       d="m 16.984407,22.020198 0,-1.000918 C 16.14005,20.886311 15.49781,20.449782 14.786425,19.818178 l 0.821808,-1.112564 c 0.518578,0.452098 0.957319,0.766042 1.376174,0.892362 l 0,-1.510669 c -0.698091,-0.179505 -1.180046,-0.41885 -1.505819,-0.718034 -0.325775,-0.305825 -0.488663,-0.78946 -0.488662,-1.354584 -1e-6,-0.571762 0.186156,-0.992318 0.558471,-1.357989 0.372312,-0.372307 0.830998,-0.570707 1.43601,-0.643847 l 0,-1.000918 0.999082,0 0,1.000918 c 0.664842,0.09308 1.339963,0.392044 1.998166,0.850781 l -0.743361,1.149352 c -0.418857,-0.299175 -0.895792,-0.549161 -1.254805,-0.648893 l 0,1.501377 c 0.718029,0.186161 1.334582,0.420701 1.673658,0.733175 0.345715,0.312481 0.518575,0.754603 0.518581,1.326368 -6e-6,0.57177 -0.192812,1.04381 -0.578417,1.416123 -0.378967,0.372314 -0.975574,0.605011 -1.613822,0.678144 l 0,1.000918 m 0.859212,-3.0528 c -4.37e-4,-0.374535 -0.402275,-0.49968 -0.859212,-0.61056 l 0,1.311202 c 0.591841,-0.06975 0.881284,-0.273166 0.859212,-0.700642 m -1.858294,-3.683379 c -0.432064,0.02021 -0.709351,0.37328 -0.709349,0.639213 -0.02208,0.476059 0.376631,0.614952 0.709349,0.692008"
+       style="font-size:9.97269535000000040px;font-weight:bold;-inkscape-font-specification:Montserrat Bold;fill:#889898;fill-opacity:1"
+       id="path3860"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccsccccccccccccccccccccc" />
+  </g>
+  <g
+     transform="scale(0.95869961,1.0430796)"
+     style="font-size:18.8508358px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3863" />
+  <path
+     style="fill:#c09730;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 30.8125,13.5 c -0.644582,8e-6 -1.212729,0.231865 -1.71875,0.71875 -0.470182,0.452409 -0.795067,1.057236 -1,1.78125 L 27,16 l 0,1 0.9,0 0,1 -0.9,0 0,1 1.09375,0 c 0.0025,0.01122 -0.0026,0.01977 0,0.03125 0.210842,0.756557 0.549321,1.363063 1.03125,1.8125 C 29.612949,21.285697 30.154741,21.5 30.78125,21.5 31.696908,21.5 32.439753,21.080174 33,20.21875 L 32.375,19.25 c -0.259042,0.32959 -0.515066,0.561447 -0.75,0.71875 -0.22892,0.149818 -0.518453,0.218751 -0.84375,0.21875 -0.65663,1e-6 -1.143452,-0.377222 -1.46875,-1.15625 -0.0046,-0.0132 0.0044,-0.01888 0,-0.03125 L 31,19 l 0,-1 -1.90625,0 0,-1 1.90625,0 0,-1 -1.6875,0 c 0.135967,-0.339203 0.323242,-0.618471 0.5625,-0.8125 0.283129,-0.232203 0.588099,-0.343743 0.9375,-0.34375 0.349393,7e-6 0.640055,0.07643 0.875,0.21875 0.240958,0.142329 0.516185,0.397947 0.78125,0.75 l 0.625,-1.03125 C 32.533503,13.919835 31.770326,13.500008 30.8125,13.5 z"
+     id="rect3874"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csccccccccccscccsccccccccccccccc" />
+  <g
+     transform="scale(0.89678137,1.115099)"
+     style="font-size:20.15239143px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3878" />
+  <g
+     transform="scale(0.90506385,1.1048944)"
+     style="font-size:20.71676826px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3891">
+    <path
+       style="font-size:10.35838412999999925px;fill:#7b7146;fill-opacity:1"
+       d="M 14.90625 27 L 16.28125 30 L 15 30 L 15 31 L 16.71875 31 L 17 31.59375 L 17 32 L 15 32 L 15 33 L 17 33 L 17 35 L 18 35 L 18 33 L 20 33 L 20 32 L 18 32 L 18 31.59375 L 18.28125 31 L 20 31 L 20 30 L 18.71875 30 L 20.09375 27 L 18.90625 27 L 17.5 30.15625 L 16.09375 27 L 14.90625 27 z "
+       transform="scale(1.1048944,0.90506387)"
+       id="path3896" />
+  </g>
+  <g
+     transform="scale(0.99069749,1.0093899)"
+     style="font-size:18.2068882px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3904">
+    <path
+       d="m 30.281701,29.720924 2.018779,0 0,0.990697 -2.018779,0 0,1.981395 3.028169,0 0,0.990697 -5.046949,0 0,-0.990697 1.00939,0 0,-1.981395 -1.00939,0 0,-0.990697 1.009385,0 0,-0.792558 c 0,-1.588978 0.855464,-2.183619 2.02548,-2.179534 1.002689,-1e-6 1.728624,0.655509 2.012079,1.418678 l -0.807512,0.414073 c -0.201878,-0.515871 -0.564356,-0.842054 -1.124457,-0.842056 -0.661896,-0.0011 -1.096205,0.411767 -1.0962,1.188839"
+       style="font-size:10.01378822000000035px;fill:#6f6f6f;fill-opacity:1"
+       id="path3909"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccc" />
+  </g>
 </svg>

--- a/Numix-Circle/48x48/apps/keurocalc.svg
+++ b/Numix-Circle/48x48/apps/keurocalc.svg
@@ -1,0 +1,1 @@
+currency.svg


### PR DESCRIPTION
Pushed icon for Currency, issue #1466 (symlinked for KEuroCalc #1497):
![currency0b](https://cloud.githubusercontent.com/assets/7050624/5943348/76e35e46-a71e-11e4-854b-e24625cb711a.png)

Alternative:
![currency6](https://cloud.githubusercontent.com/assets/7050624/5943353/845a35d6-a71e-11e4-8de4-985be2e2d276.png)

If both are good I could use one for KEuroCalc.
Or just symlink KEuroCalc to the existing Grisbi icon.

