### PR TITLE
Icon for KGeography. Fixes #1500

### DIFF
--- a/Numix-Circle/48x48/apps/kgeography.svg
+++ b/Numix-Circle/48x48/apps/kgeography.svg
@@ -1,0 +1,342 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kgeography1.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="true"
+     inkscape:zoom="22.627416"
+     inkscape:cx="18.043869"
+     inkscape:cy="23.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#61a373;stop-opacity:1;"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#6eaa7e;stop-opacity:1;"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#f6b22e"
+         stop-opacity="1"
+         id="stop7"
+         offset="0"
+         style="stop-color:#78dc23;stop-opacity:1;" />
+      <stop
+         offset="1"
+         stop-color="#f7b941"
+         stop-opacity="1"
+         id="stop9"
+         style="stop-color:#83df35;stop-opacity:1;" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-159244691">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-171249618">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient4393">
+      <stop
+         style="stop-color:#7d683e;stop-opacity:1;"
+         offset="0"
+         id="stop4395" />
+      <stop
+         style="stop-color:#7a6841;stop-opacity:1;"
+         offset="1"
+         id="stop4397" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient6121">
+      <stop
+         style="stop-color:#cc5f50;stop-opacity:1;"
+         offset="0"
+         id="stop6123" />
+      <stop
+         style="stop-color:#d57a6e;stop-opacity:1;"
+         offset="1"
+         id="stop6125" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3764-7"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#46baea"
+         stop-opacity="1"
+         id="stop7-0" />
+      <stop
+         offset="1"
+         stop-color="#58c2ec"
+         stop-opacity="1"
+         id="stop9-2" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764-0"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#46baea"
+         stop-opacity="1"
+         id="stop7-2" />
+      <stop
+         offset="1"
+         stop-color="#58c2ec"
+         stop-opacity="1"
+         id="stop9-5" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3764-0-5"
+       id="linearGradient3877-7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.65208531,0,0,0.65217391,8.3479147,8.3478261)"
+       y1="47"
+       x2="0"
+       y2="1" />
+    <linearGradient
+       id="linearGradient3764-0-5"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#46baea"
+         stop-opacity="1"
+         id="stop7-2-8" />
+      <stop
+         offset="1"
+         stop-color="#58c2ec"
+         stop-opacity="1"
+         id="stop9-5-4" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g3882">
+    <g
+       transform="translate(0,-1)"
+       id="g3860">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+         d="m 13,15 0,20 2.25,0 c 1.265478,1.80946 3.374377,3 5.75,3 2.375623,0 4.484522,-1.19054 5.75,-3 L 37,35 37,15 13,15 z"
+         id="path3807" />
+      <g
+         id="g3822">
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3030"
+           d="m 12,14 24,0 0,20 -24,0 z"
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           sodipodi:nodetypes="ccccc"
+           inkscape:connector-curvature="0"
+           id="rect3032"
+           d="m 13,15 22,0 0,18 -22,0 z"
+           style="fill:#a4a8ee;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           sodipodi:nodetypes="ccscscc"
+           id="path73"
+           d="m 13,33 0,-10 c 0.578771,-0.334723 2.102633,-1.367544 4,-2 3,-1 6,-0.663659 8,1 2.285148,2.019195 0.3125,3.168812 3,3.483686 2.043678,0.239442 6.702683,2.653898 7,3.328814 C 35,29.285546 35,33 35,33"
+           inkscape:connector-curvature="0"
+           style="fill:#5dae38;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           sodipodi:nodetypes="sssss"
+           inkscape:connector-curvature="0"
+           id="path3832"
+           d="m 33.226175,20.999999 c 0,0.460027 -1.447715,2 -2,2 -0.552285,0 -3,-1.539973 -3,-2 0,-0.460026 1.447715,-0.999999 2,-0.999999 0.552285,0 3,0.539973 3,0.999999 z"
+           style="fill:#5dae38;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+         d="m 21,24 c -3.865993,0 -7,3.134007 -7,7 0,1.075003 0.254495,2.089837 0.6875,3 l 12.625,0 C 27.745505,33.089837 28,32.075003 28,31 28,27.134007 24.865993,24 21,24 z"
+         id="rect3030-8" />
+      <g
+         id="g3032"
+         transform="translate(1.2e-6,1.0000027)">
+        <path
+           transform="matrix(2,0,0,2,-13.000001,-36.000003)"
+           d="M 20,32.5 C 20,34.432997 18.432997,36 16.5,36 14.567003,36 13,34.432997 13,32.5 13,30.567003 14.567003,29 16.5,29 c 1.932997,0 3.5,1.567003 3.5,3.5 z"
+           sodipodi:ry="3.5"
+           sodipodi:rx="3.5"
+           sodipodi:cy="32.5"
+           sodipodi:cx="16.5"
+           id="path3837"
+           style="fill:#858585;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:type="arc" />
+        <path
+           sodipodi:type="arc"
+           style="fill:#505050;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           id="path3839"
+           sodipodi:cx="16.5"
+           sodipodi:cy="32.5"
+           sodipodi:rx="3.5"
+           sodipodi:ry="3.5"
+           d="M 20,32.5 C 20,34.432997 18.432997,36 16.5,36 14.567003,36 13,34.432997 13,32.5 13,30.567003 14.567003,29 16.5,29 c 1.932997,0 3.5,1.567003 3.5,3.5 z"
+           transform="matrix(1.7142857,0,0,1.7142857,-8.2857153,-26.714288)" />
+        <path
+           sodipodi:nodetypes="cccc"
+           inkscape:connector-curvature="0"
+           id="path3843"
+           d="M 23.535535,25.464466 20.707108,29.707103 19.292893,28.29289 z"
+           style="fill:#ff4e4e;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#7f7fc4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16.464468,32.535533 2.828425,-4.242643 1.414215,1.414213 z"
+           id="path3846"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           transform="matrix(1,0,0,1.1324657,2.0000009,-6.2389052)"
+           d="m 19,31.116972 c 0,0.487683 -0.447715,0.883029 -1,0.883029 -0.552285,0 -1,-0.395346 -1,-0.883029 0,-0.487683 0.447715,-0.883029 1,-0.883029 0.552285,0 1,0.395346 1,0.883029 z"
+           sodipodi:ry="0.88302898"
+           sodipodi:rx="1"
+           sodipodi:cy="31.116972"
+           sodipodi:cx="18"
+           id="path3841"
+           style="fill:#858585;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:type="arc" />
+      </g>
+    </g>
+    <path
+       sodipodi:nodetypes="sssss"
+       inkscape:connector-curvature="0"
+       id="path3943"
+       d="m 30,15.662112 c 0,0.460027 -0.885215,2 -1.4375,2 -0.552285,0 -6,0.460027 -6,0 0,-0.460026 3.447715,-2 4,-2 0.552285,0 3.4375,-0.460026 3.4375,0 z"
+       style="fill:#5dae38;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for KGeography. Fixes #1500

Pushed:
![kgeography1c](https://cloud.githubusercontent.com/assets/7050624/5948183/3fb9874a-a743-11e4-8683-8f72c43f1d77.png)
Alt:
![kgeography4b](https://cloud.githubusercontent.com/assets/7050624/5948192/4bb651ea-a743-11e4-81ab-3c4bdf0ef751.png)

