### PR TITLE
Icon for YAGF. Fixes #1103

### DIFF
--- a/Numix-Circle/48x48/apps/yagf.svg
+++ b/Numix-Circle/48x48/apps/yagf.svg
@@ -1,0 +1,1308 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.5 r10040"
+   width="100%"
+   height="100%"
+   sodipodi:docname="yagf.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="true"
+     inkscape:zoom="8"
+     inkscape:cx="12.342801"
+     inkscape:cy="22.158711"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#d2bd24;stop-opacity:1;"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#dbc62f;stop-opacity:1;"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-442087651-1">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-6-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-4-0" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g6075">
+    <g
+       transform="translate(-39,-5.9999999)"
+       id="g3606">
+      <g
+         id="g61-6"
+         transform="translate(39,6.9999999)">
+        <g
+           transform="translate(1,-2)"
+           id="g3858">
+          <path
+             sodipodi:nodetypes="ccccccccccccccccccc"
+             inkscape:connector-curvature="0"
+             id="path5098"
+             d="m 11,13 0,23.84375 C 23.282855,31.63663 15.528737,13.185727 28,13 z m 17,0 c 2.305128,0 4.616902,0.902441 6.375,2.65625 C 36.129098,17.409555 37,19.69709 37,22 l 0,-9 z m 9,9 c 0,2.30291 -0.870902,4.621194 -2.625,6.375 -12.873922,2.440017 -9.468361,-1.686844 -16.28125,5.6875 L 13.15625,39 37,39 z M 13.15625,39 11,36.84375 11,39 z"
+             style="fill:#000000;fill-opacity:0.11952192;fill-rule:evenodd;stroke:none" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g5601">
+      <g
+         id="g5145">
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#f5efef;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           id="path67-3"
+           d="m 37,11 -26,0 0,26 26,0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,13 1,0 0,1 -1,0 z"
+           id="rect4045" />
+        <path
+           id="rect4047"
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,13 1,0 0,1 -1,0 z m -2,0 1,0 0,1 -1,0 z m -1,0 1,0 0,1 -1,0 z" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,13 1,0 0,1 -1,0 z"
+           id="rect4049" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,13 1,0 0,1 -1,0 z"
+           id="rect4051" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,13 1,0 0,1 -1,0 z"
+           id="rect4053" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,13 1,0 0,1 -1,0 z"
+           id="rect4055" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,13 1,0 0,1 -1,0 z"
+           id="rect4057" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,14 1,0 0,1 -1,0 z"
+           id="rect4059" />
+        <rect
+           y="16"
+           x="14"
+           height="1"
+           width="1"
+           id="rect4061"
+           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,14 1,0 0,1 -1,0 z"
+           id="rect4063" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,14 1,0 0,1 -1,0 z"
+           id="rect4065" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,14 1,0 0,1 -1,0 z"
+           id="rect4067" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,14 1,0 0,1 -1,0 z"
+           id="rect4069" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,14 1,0 0,1 -1,0 z"
+           id="rect4071" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,14 1,0 0,1 -1,0 z"
+           id="rect4073" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,16 1,0 0,1 -1,0 z"
+           id="rect4075" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,16 1,0 0,1 -1,0 z"
+           id="rect4077" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,14 1,0 0,1 -1,0 z"
+           id="rect4079" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,16 1,0 0,1 -1,0 z"
+           id="rect4081" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,16 1,0 0,1 -1,0 z"
+           id="rect4083" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,16 1,0 0,1 -1,0 z"
+           id="rect4085" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,16 1,0 0,1 -1,0 z"
+           id="rect4087" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,15 1,0 0,1 -1,0 z"
+           id="rect4089" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,15 1,0 0,1 -1,0 z"
+           id="rect4091" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,15 1,0 0,1 -1,0 z"
+           id="rect4093" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,15 1,0 0,1 -1,0 z"
+           id="rect4095" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,15 1,0 0,1 -1,0 z"
+           id="rect4097" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,15 1,0 0,1 -1,0 z"
+           id="rect4099" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,15 1,0 0,1 -1,0 z"
+           id="rect4101" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,15 1,0 0,1 -1,0 z"
+           id="rect4103" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,15 1,0 0,1 -1,0 z"
+           id="rect4105" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,13 1,0 0,1 -1,0 z"
+           id="rect4107" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,13 1,0 0,1 -1,0 z"
+           id="rect4109" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,14 1,0 0,1 -1,0 z"
+           id="rect4125" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,14 1,0 0,1 -1,0 z"
+           id="rect4139" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,13 1,0 0,1 -1,0 z"
+           id="rect4177" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,13 1,0 0,1 -1,0 z"
+           id="rect4187" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,13 1,0 0,1 -1,0 z"
+           id="rect4189" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,14 1,0 0,1 -1,0 z"
+           id="rect4191" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,15 1,0 0,1 -1,0 z"
+           id="rect4197" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,16 1,0 0,1 -1,0 z"
+           id="rect4205" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,14 1,0 0,1 -1,0 z"
+           id="rect4207" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,18 1,0 0,1 -1,0 z"
+           id="rect4209" />
+        <path
+           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,18 1,0 0,1 -1,0 z"
+           id="rect4211" />
+        <path
+           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,18 1,0 0,1 -1,0 z"
+           id="rect4213" />
+        <path
+           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,18 1,0 0,1 -1,0 z"
+           id="rect4215" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,18 1,0 0,1 -1,0 z"
+           id="rect4217" />
+        <path
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,18 1,0 0,1 -1,0 z"
+           id="rect4219" />
+        <rect
+           y="18"
+           x="31"
+           height="1"
+           width="1"
+           id="rect4231"
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,18 1,0 0,1 -1,0 z"
+           id="rect4237" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,17 1,0 0,1 -1,0 z"
+           id="rect4239" />
+        <path
+           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,17 1,0 0,1 -1,0 z"
+           id="rect4241" />
+        <path
+           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,17 1,0 0,1 -1,0 z"
+           id="rect4243" />
+        <path
+           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,17 1,0 0,1 -1,0 z"
+           id="rect4247" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,17 1,0 0,1 -1,0 z"
+           id="rect4249" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,17 1,0 0,1 -1,0 z"
+           id="rect4251" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,17 1,0 0,1 -1,0 z"
+           id="rect4253" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,17 1,0 0,1 -1,0 z"
+           id="rect4255" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,19 1,0 0,1 -1,0 z"
+           id="rect4287" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,19 1,0 0,1 -1,0 z"
+           id="rect4289" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,19 1,0 0,1 -1,0 z"
+           id="rect4291" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,19 1,0 0,1 -1,0 z"
+           id="rect4293" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,19 1,0 0,1 -1,0 z"
+           id="rect4295" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,19 1,0 0,1 -1,0 z"
+           id="rect4297" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,19 1,0 0,1 -1,0 z"
+           id="rect4299" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,19 1,0 0,1 -1,0 z"
+           id="rect4301" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,20 1,0 0,1 -1,0 z"
+           id="rect4305" />
+        <rect
+           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           id="rect4307"
+           width="1"
+           height="1"
+           x="14"
+           y="22" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,20 1,0 0,1 -1,0 z"
+           id="rect4309" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,20 1,0 0,1 -1,0 z"
+           id="rect4311" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,20 1,0 0,1 -1,0 z"
+           id="rect4313" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,20 1,0 0,1 -1,0 z"
+           id="rect4315" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,20 1,0 0,1 -1,0 z"
+           id="rect4317" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,22 1,0 0,1 -1,0 z"
+           id="rect4321" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,22 1,0 0,1 -1,0 z"
+           id="rect4323" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,20 1,0 0,1 -1,0 z"
+           id="rect4325" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,22 1,0 0,1 -1,0 z"
+           id="rect4327" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,22 1,0 0,1 -1,0 z"
+           id="rect4329" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,22 1,0 0,1 -1,0 z"
+           id="rect4331" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,21 1,0 0,1 -1,0 z"
+           id="rect4335" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,21 1,0 0,1 -1,0 z"
+           id="rect4337" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,21 1,0 0,1 -1,0 z"
+           id="rect4339" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,21 1,0 0,1 -1,0 z"
+           id="rect4341" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,21 1,0 0,1 -1,0 z"
+           id="rect4343" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,21 1,0 0,1 -1,0 z"
+           id="rect4345" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,21 1,0 0,1 -1,0 z"
+           id="rect4349" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,21 1,0 0,1 -1,0 z"
+           id="rect4351" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,22 1,0 0,1 -1,0 z"
+           id="rect4451" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,24 1,0 0,1 -1,0 z"
+           id="rect4455" />
+        <path
+           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,24 1,0 0,1 -1,0 z"
+           id="rect4457" />
+        <path
+           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,24 1,0 0,1 -1,0 z"
+           id="rect4459" />
+        <path
+           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,24 1,0 0,1 -1,0 z"
+           id="rect4461" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,24 1,0 0,1 -1,0 z"
+           id="rect4463" />
+        <path
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,24 1,0 0,1 -1,0 z"
+           id="rect4465" />
+        <rect
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           id="rect4477"
+           width="1"
+           height="1"
+           x="31"
+           y="24" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,24 1,0 0,1 -1,0 z"
+           id="rect4483" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,23 1,0 0,1 -1,0 z"
+           id="rect4485" />
+        <path
+           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,23 1,0 0,1 -1,0 z"
+           id="rect4487" />
+        <path
+           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,23 1,0 0,1 -1,0 z"
+           id="rect4489" />
+        <path
+           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,23 1,0 0,1 -1,0 z"
+           id="rect4493" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,23 1,0 0,1 -1,0 z"
+           id="rect4495" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,23 1,0 0,1 -1,0 z"
+           id="rect4497" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,23 1,0 0,1 -1,0 z"
+           id="rect4499" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,23 1,0 0,1 -1,0 z"
+           id="rect4501" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,25 1,0 0,1 -1,0 z"
+           id="rect4533" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,25 1,0 0,1 -1,0 z"
+           id="rect4535" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,25 1,0 0,1 -1,0 z"
+           id="rect4537" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,25 1,0 0,1 -1,0 z"
+           id="rect4539" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,25 1,0 0,1 -1,0 z"
+           id="rect4541" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,25 1,0 0,1 -1,0 z"
+           id="rect4543" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,25 1,0 0,1 -1,0 z"
+           id="rect4545" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,25 1,0 0,1 -1,0 z"
+           id="rect4547" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,25 1,0 0,1 -1,0 z"
+           id="rect4549" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,26 1,0 0,1 -1,0 z"
+           id="rect4551" />
+        <rect
+           y="28"
+           x="14"
+           height="1"
+           width="1"
+           id="rect4553"
+           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,26 1,0 0,1 -1,0 z"
+           id="rect4555" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,26 1,0 0,1 -1,0 z"
+           id="rect4557" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,26 1,0 0,1 -1,0 z"
+           id="rect4559" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,26 1,0 0,1 -1,0 z"
+           id="rect4561" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,26 1,0 0,1 -1,0 z"
+           id="rect4563" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,28 1,0 0,1 -1,0 z"
+           id="rect4567" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,28 1,0 0,1 -1,0 z"
+           id="rect4569" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,26 1,0 0,1 -1,0 z"
+           id="rect4571" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,28 1,0 0,1 -1,0 z"
+           id="rect4573" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,28 1,0 0,1 -1,0 z"
+           id="rect4575" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,28 1,0 0,1 -1,0 z"
+           id="rect4577" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,27 1,0 0,1 -1,0 z"
+           id="rect4581" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,27 1,0 0,1 -1,0 z"
+           id="rect4583" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,27 1,0 0,1 -1,0 z"
+           id="rect4585" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,27 1,0 0,1 -1,0 z"
+           id="rect4587" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,27 1,0 0,1 -1,0 z"
+           id="rect4589" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,27 1,0 0,1 -1,0 z"
+           id="rect4591" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,27 1,0 0,1 -1,0 z"
+           id="rect4597" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,26 1,0 0,1 -1,0 z"
+           id="rect4621" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,28 1,0 0,1 -1,0 z"
+           id="rect4633" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,28 1,0 0,1 -1,0 z"
+           id="rect4635" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,27 1,0 0,1 -1,0 z"
+           id="rect4641" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,27 1,0 0,1 -1,0 z"
+           id="rect4647" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,26 1,0 0,1 -1,0 z"
+           id="rect4661" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,26 1,0 0,1 -1,0 z"
+           id="rect4673" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,27 1,0 0,1 -1,0 z"
+           id="rect4675" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,25 1,0 0,1 -1,0 z"
+           id="rect4681" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,26 1,0 0,1 -1,0 z"
+           id="rect4683" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,28 1,0 0,1 -1,0 z"
+           id="rect4685" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,27 1,0 0,1 -1,0 z"
+           id="rect4687" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,27 1,0 0,1 -1,0 z"
+           id="rect4689" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,28 1,0 0,1 -1,0 z"
+           id="rect4691" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,28 1,0 0,1 -1,0 z"
+           id="rect4693" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,28 1,0 0,1 -1,0 z"
+           id="rect4695" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,28 1,0 0,1 -1,0 z"
+           id="rect4697" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,26 1,0 0,1 -1,0 z"
+           id="rect4699" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,30 1,0 0,1 -1,0 z"
+           id="rect4701" />
+        <path
+           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,30 1,0 0,1 -1,0 z"
+           id="rect4703" />
+        <path
+           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,30 1,0 0,1 -1,0 z"
+           id="rect4705" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,30 1,0 0,1 -1,0 z"
+           id="rect4709" />
+        <path
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,30 1,0 0,1 -1,0 z"
+           id="rect4711" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,30 1,0 0,1 -1,0 z"
+           id="rect4713" />
+        <path
+           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,30 1,0 0,1 -1,0 z"
+           id="rect4715" />
+        <path
+           style="fill:#e2e2e2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,30 1,0 0,1 -1,0 z"
+           id="rect4717" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,30 1,0 0,1 -1,0 z"
+           id="rect4719" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 27,30 1,0 0,1 -1,0 z"
+           id="rect4721" />
+        <rect
+           y="30"
+           x="31"
+           height="1"
+           width="1"
+           id="rect4723"
+           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,30 1,0 0,1 -1,0 z"
+           id="rect4725" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,30 1,0 0,1 -1,0 z"
+           id="rect4727" />
+        <path
+           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,30 1,0 0,1 -1,0 z"
+           id="rect4729" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,29 1,0 0,1 -1,0 z"
+           id="rect4731" />
+        <path
+           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,29 1,0 0,1 -1,0 z"
+           id="rect4733" />
+        <path
+           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,29 1,0 0,1 -1,0 z"
+           id="rect4737" />
+        <path
+           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,29 1,0 0,1 -1,0 z"
+           id="rect4739" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,29 1,0 0,1 -1,0 z"
+           id="rect4741" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,29 1,0 0,1 -1,0 z"
+           id="rect4743" />
+        <path
+           style="fill:#b2b2b2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,29 1,0 0,1 -1,0 z"
+           id="rect4749" />
+        <path
+           style="fill:#b2b2b2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,29 1,0 0,1 -1,0 z"
+           id="rect4751" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 24,29 1,0 0,1 -1,0 z"
+           id="rect4753" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,29 1,0 0,1 -1,0 z"
+           id="rect4755" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,29 1,0 0,1 -1,0 z"
+           id="rect4757" />
+        <path
+           style="fill:#b1b1b1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 29,29 1,0 0,1 -1,0 z"
+           id="rect4759" />
+        <path
+           style="fill:#b1b1b1;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,29 1,0 0,1 -1,0 z"
+           id="rect4761" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 26,29 1,0 0,1 -1,0 z"
+           id="rect4763" />
+        <path
+           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 27,29 1,0 0,1 -1,0 z"
+           id="rect4765" />
+        <path
+           style="fill:#cacaca;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,29 1,0 0,1 -1,0 z"
+           id="rect4767" />
+        <path
+           style="fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,29 1,0 0,1 -1,0 z"
+           id="rect4769" />
+        <path
+           style="fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,29 1,0 0,1 -1,0 z"
+           id="rect4771" />
+        <path
+           style="fill:#c2c2c2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,29 1,0 0,1 -1,0 z"
+           id="rect4773" />
+        <path
+           style="fill:#c7c7c7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,29 1,0 0,1 -1,0 z"
+           id="rect4775" />
+        <path
+           style="fill:#c7c7c7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,29 1,0 0,1 -1,0 z"
+           id="rect4777" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,31 1,0 0,1 -1,0 z"
+           id="rect4779" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,31 1,0 0,1 -1,0 z"
+           id="rect4781" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,31 1,0 0,1 -1,0 z"
+           id="rect4783" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,31 1,0 0,1 -1,0 z"
+           id="rect4791" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,31 1,0 0,1 -1,0 z"
+           id="rect4793" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,31 1,0 0,1 -1,0 z"
+           id="rect4795" />
+        <rect
+           y="32"
+           x="12"
+           height="1"
+           width="1"
+           id="rect4797"
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <rect
+           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           id="rect4799"
+           width="1"
+           height="1"
+           x="14"
+           y="34" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,32 1,0 0,1 -1,0 z"
+           id="rect4803" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,32 1,0 0,1 -1,0 z"
+           id="rect4807" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,32 1,0 0,1 -1,0 z"
+           id="rect4809" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,32 1,0 0,1 -1,0 z"
+           id="rect4811" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,34 1,0 0,1 -1,0 z"
+           id="rect4813" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 14,34 1,0 0,1 -1,0 z"
+           id="rect4815" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 13,32 1,0 0,1 -1,0 z"
+           id="rect4817" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,34 1,0 0,1 -1,0 z"
+           id="rect4819" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 15,34 1,0 0,1 -1,0 z"
+           id="rect4823" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,34 1,0 0,1 -1,0 z"
+           id="rect4825" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 16,33 1,0 0,1 -1,0 z"
+           id="rect4827" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 18,33 1,0 0,1 -1,0 z"
+           id="rect4829" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 12,33 1,0 0,1 -1,0 z"
+           id="rect4833" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 20,33 1,0 0,1 -1,0 z"
+           id="rect4839" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 19,33 1,0 0,1 -1,0 z"
+           id="rect4841" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 17,33 1,0 0,1 -1,0 z"
+           id="rect4843" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,31 1,0 0,1 -1,0 z"
+           id="rect4845" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,31 1,0 0,1 -1,0 z"
+           id="rect4847" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,31 1,0 0,1 -1,0 z"
+           id="rect4849" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 24,31 1,0 0,1 -1,0 z"
+           id="rect4851" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,31 1,0 0,1 -1,0 z"
+           id="rect4853" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 26,31 1,0 0,1 -1,0 z"
+           id="rect4855" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 27,31 1,0 0,1 -1,0 z"
+           id="rect4857" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,31 1,0 0,1 -1,0 z"
+           id="rect4859" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 29,31 1,0 0,1 -1,0 z"
+           id="rect4861" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,32 1,0 0,1 -1,0 z"
+           id="rect4863" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,32 1,0 0,1 -1,0 z"
+           id="rect4865" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,32 1,0 0,1 -1,0 z"
+           id="rect4867" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 24,32 1,0 0,1 -1,0 z"
+           id="rect4869" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 27,32 1,0 0,1 -1,0 z"
+           id="rect4871" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,32 1,0 0,1 -1,0 z"
+           id="rect4873" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 29,32 1,0 0,1 -1,0 z"
+           id="rect4875" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,32 1,0 0,1 -1,0 z"
+           id="rect4877" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,34 1,0 0,1 -1,0 z"
+           id="rect4879" />
+        <path
+           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,34 1,0 0,1 -1,0 z"
+           id="rect4881" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 25,33 1,0 0,1 -1,0 z"
+           id="rect4883" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 27,33 1,0 0,1 -1,0 z"
+           id="rect4885" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 22,33 1,0 0,1 -1,0 z"
+           id="rect4887" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 21,33 1,0 0,1 -1,0 z"
+           id="rect4889" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 24,33 1,0 0,1 -1,0 z"
+           id="rect4891" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 23,33 1,0 0,1 -1,0 z"
+           id="rect4893" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 29,33 1,0 0,1 -1,0 z"
+           id="rect4895" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,33 1,0 0,1 -1,0 z"
+           id="rect4897" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 26,33 1,0 0,1 -1,0 z"
+           id="rect4899" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,31 1,0 0,1 -1,0 z"
+           id="rect4901" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,31 1,0 0,1 -1,0 z"
+           id="rect4903" />
+        <path
+           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,32 1,0 0,1 -1,0 z"
+           id="rect4905" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,32 1,0 0,1 -1,0 z"
+           id="rect4907" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,33 1,0 0,1 -1,0 z"
+           id="rect4909" />
+        <path
+           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,33 1,0 0,1 -1,0 z"
+           id="rect4911" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,31 1,0 0,1 -1,0 z"
+           id="rect4913" />
+        <path
+           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,31 1,0 0,1 -1,0 z"
+           id="rect4915" />
+        <path
+           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,32 1,0 0,1 -1,0 z"
+           id="rect4917" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,32 1,0 0,1 -1,0 z"
+           id="rect4919" />
+        <path
+           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 33,33 1,0 0,1 -1,0 z"
+           id="rect4921" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 32,33 1,0 0,1 -1,0 z"
+           id="rect4923" />
+        <path
+           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,31 1,0 0,1 -1,0 z"
+           id="rect4925" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,31 1,0 0,1 -1,0 z"
+           id="rect4927" />
+        <path
+           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,32 1,0 0,1 -1,0 z"
+           id="rect4929" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,34 1,0 0,1 -1,0 z"
+           id="rect4931" />
+        <path
+           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 34,33 1,0 0,1 -1,0 z"
+           id="rect4933" />
+        <path
+           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,33 1,0 0,1 -1,0 z"
+           id="rect4935" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 31,34 1,0 0,1 -1,0 z"
+           id="rect4937" />
+        <path
+           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 28,34 1,0 0,1 -1,0 z"
+           id="rect4939" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 30,34 1,0 0,1 -1,0 z"
+           id="rect4941" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,34 1,0 0,1 -1,0 z"
+           id="rect4943" />
+        <path
+           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           d="m 35,32 1,0 0,1 -1,0 z"
+           id="rect4945" />
+      </g>
+      <g
+         id="g5126">
+        <g
+           id="g3257">
+          <g
+             transform="translate(0,-0.004)"
+             id="g35">
+            <g
+               clip-path="url(#clipPath-442087651-1)"
+               id="g37">
+              <g
+                 transform="translate(1,1)"
+                 id="g39">
+                <g
+                   style="opacity:0.1"
+                   id="g41">
+                  <!-- color: #cccdb6 -->
+                  <g
+                     id="g43" />
+                </g>
+              </g>
+            </g>
+          </g>
+          <g
+             id="g3251">
+            <path
+               inkscape:connector-curvature="0"
+               id="path5108"
+               d="m 29,12 c -2.309128,0 -4.620902,0.902442 -6.375,2.65625 -3.255111,3.250858 -3.466079,8.378689 -0.6875,11.90625 L 17.25,31.21875 16.9375,30.90625 12,35.84375 14.15625,38 19.09375,33.0625 18.75,32.75 23.40625,28.09375 c 3.529423,2.789485 8.709198,2.537473 11.96875,-0.71875 3.508195,-3.507613 3.508195,-9.21214 0,-12.71875 C 33.616902,12.902441 31.305128,12 29,12 z m 0,1.46875 c 1.922107,0 3.839419,0.746913 5.3125,2.21875 2.941164,2.940673 2.941164,7.684327 0,10.625 -2.945163,2.940672 -7.711087,2.940672 -10.65625,0 -2.941164,-2.940673 -2.941164,-7.684327 0,-10.625 C 25.129332,14.21466 27.074893,13.46875 29,13.46875 z"
+               style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none" />
+            <path
+               style="fill:#f5efef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 36.602,19.898 c 0,4.69679 -3.805,8.5 -8.5,8.5 -4.699,0 -8.504,-3.80321 -8.5,-8.5 -0.004,-4.692792 3.801,-8.5 8.5,-8.5 4.695,0 8.5,3.807208 8.5,8.5 m 0,0"
+               id="path63" />
+            <path
+               sodipodi:nodetypes="cccc"
+               style="fill:#d24c37;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 22.622,26.866 -1.504,-1.504 -4.934,4.934 1.504,1.504"
+               id="path69-5" />
+            <path
+               style="fill:#b19b9b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 27.986499,11.000001 c -2.309128,0 -4.598255,0.8869 -6.352353,2.640708 -3.512195,3.507606 -3.512195,9.221973 0,12.728584 3.508195,3.507609 9.223513,3.507609 12.734708,0 3.508195,-3.507613 3.508195,-9.221974 0,-12.728584 C 32.610756,11.8869 30.290627,11 27.985499,11 m 0,1.479833 c 1.922107,0 3.840214,0.726923 5.313295,2.19876 2.941164,2.940673 2.941164,7.679146 0,10.619819 -2.945163,2.940672 -7.684427,2.940672 -10.62959,0 -2.941164,-2.940673 -2.941164,-7.679146 0,-10.619819 1.473082,-1.47284 3.391188,-2.19876 5.316295,-2.19876 m 0,0"
+               id="path65" />
+            <path
+               sodipodi:nodetypes="cccc"
+               style="fill:#222b30;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="M 18.079,32.066 15.934,29.921 11,34.855 13.145,37"
+               id="path67" />
+          </g>
+        </g>
+        <g
+           id="text5091"
+           style="font-size:19.6648159px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+           transform="scale(0.96219942,1.0392856)">
+          <path
+             sodipodi:nodetypes="cccccccccccc"
+             inkscape:connector-curvature="0"
+             id="path5096"
+             style="font-size:13.76537228px;font-weight:bold;fill:#606060;-inkscape-font-specification:Montserrat Bold"
+             d="m 32.011372,23.092789 -0.832804,-1.924402 -4.157142,0 -0.832806,1.924402 -2.285052,0 4.157143,-9.621996 2.078571,0 4.157142,9.621996 -2.285052,0 m -2.911375,-6.735399 -1.247143,2.886598 2.494285,0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/yagf.svg
+++ b/Numix-Circle/48x48/apps/yagf.svg
@@ -23,7 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,10 +39,10 @@
      inkscape:window-width="1366"
      inkscape:window-height="713"
      id="namedview63"
-     showgrid="true"
-     inkscape:zoom="8"
-     inkscape:cx="12.342801"
-     inkscape:cy="22.158711"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="23.419945"
+     inkscape:cy="23.194245"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -139,1170 +139,160 @@
      style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
      id="text3791" />
   <g
-     id="g6075">
+     id="g4149">
     <g
-       transform="translate(-39,-5.9999999)"
-       id="g3606">
+       id="g4080">
       <g
-         id="g61-6"
-         transform="translate(39,6.9999999)">
+         id="g6075">
         <g
-           transform="translate(1,-2)"
-           id="g3858">
-          <path
-             sodipodi:nodetypes="ccccccccccccccccccc"
-             inkscape:connector-curvature="0"
-             id="path5098"
-             d="m 11,13 0,23.84375 C 23.282855,31.63663 15.528737,13.185727 28,13 z m 17,0 c 2.305128,0 4.616902,0.902441 6.375,2.65625 C 36.129098,17.409555 37,19.69709 37,22 l 0,-9 z m 9,9 c 0,2.30291 -0.870902,4.621194 -2.625,6.375 -12.873922,2.440017 -9.468361,-1.686844 -16.28125,5.6875 L 13.15625,39 37,39 z M 13.15625,39 11,36.84375 11,39 z"
-             style="fill:#000000;fill-opacity:0.11952192;fill-rule:evenodd;stroke:none" />
-        </g>
-      </g>
-    </g>
-    <g
-       id="g5601">
-      <g
-         id="g5145">
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:#f5efef;fill-opacity:1;fill-rule:evenodd;stroke:none"
-           id="path67-3"
-           d="m 37,11 -26,0 0,26 26,0"
-           sodipodi:nodetypes="cccc" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,13 1,0 0,1 -1,0 z"
-           id="rect4045" />
-        <path
-           id="rect4047"
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,13 1,0 0,1 -1,0 z m -2,0 1,0 0,1 -1,0 z m -1,0 1,0 0,1 -1,0 z" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,13 1,0 0,1 -1,0 z"
-           id="rect4049" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,13 1,0 0,1 -1,0 z"
-           id="rect4051" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,13 1,0 0,1 -1,0 z"
-           id="rect4053" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,13 1,0 0,1 -1,0 z"
-           id="rect4055" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,13 1,0 0,1 -1,0 z"
-           id="rect4057" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,14 1,0 0,1 -1,0 z"
-           id="rect4059" />
-        <rect
-           y="16"
-           x="14"
-           height="1"
-           width="1"
-           id="rect4061"
-           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,14 1,0 0,1 -1,0 z"
-           id="rect4063" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,14 1,0 0,1 -1,0 z"
-           id="rect4065" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,14 1,0 0,1 -1,0 z"
-           id="rect4067" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,14 1,0 0,1 -1,0 z"
-           id="rect4069" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,14 1,0 0,1 -1,0 z"
-           id="rect4071" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,14 1,0 0,1 -1,0 z"
-           id="rect4073" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,16 1,0 0,1 -1,0 z"
-           id="rect4075" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,16 1,0 0,1 -1,0 z"
-           id="rect4077" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,14 1,0 0,1 -1,0 z"
-           id="rect4079" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,16 1,0 0,1 -1,0 z"
-           id="rect4081" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,16 1,0 0,1 -1,0 z"
-           id="rect4083" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,16 1,0 0,1 -1,0 z"
-           id="rect4085" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,16 1,0 0,1 -1,0 z"
-           id="rect4087" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,15 1,0 0,1 -1,0 z"
-           id="rect4089" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,15 1,0 0,1 -1,0 z"
-           id="rect4091" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,15 1,0 0,1 -1,0 z"
-           id="rect4093" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,15 1,0 0,1 -1,0 z"
-           id="rect4095" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,15 1,0 0,1 -1,0 z"
-           id="rect4097" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,15 1,0 0,1 -1,0 z"
-           id="rect4099" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,15 1,0 0,1 -1,0 z"
-           id="rect4101" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,15 1,0 0,1 -1,0 z"
-           id="rect4103" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,15 1,0 0,1 -1,0 z"
-           id="rect4105" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,13 1,0 0,1 -1,0 z"
-           id="rect4107" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,13 1,0 0,1 -1,0 z"
-           id="rect4109" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,14 1,0 0,1 -1,0 z"
-           id="rect4125" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,14 1,0 0,1 -1,0 z"
-           id="rect4139" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,13 1,0 0,1 -1,0 z"
-           id="rect4177" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,13 1,0 0,1 -1,0 z"
-           id="rect4187" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,13 1,0 0,1 -1,0 z"
-           id="rect4189" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,14 1,0 0,1 -1,0 z"
-           id="rect4191" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,15 1,0 0,1 -1,0 z"
-           id="rect4197" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,16 1,0 0,1 -1,0 z"
-           id="rect4205" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,14 1,0 0,1 -1,0 z"
-           id="rect4207" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,18 1,0 0,1 -1,0 z"
-           id="rect4209" />
-        <path
-           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,18 1,0 0,1 -1,0 z"
-           id="rect4211" />
-        <path
-           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,18 1,0 0,1 -1,0 z"
-           id="rect4213" />
-        <path
-           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,18 1,0 0,1 -1,0 z"
-           id="rect4215" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,18 1,0 0,1 -1,0 z"
-           id="rect4217" />
-        <path
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,18 1,0 0,1 -1,0 z"
-           id="rect4219" />
-        <rect
-           y="18"
-           x="31"
-           height="1"
-           width="1"
-           id="rect4231"
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,18 1,0 0,1 -1,0 z"
-           id="rect4237" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,17 1,0 0,1 -1,0 z"
-           id="rect4239" />
-        <path
-           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,17 1,0 0,1 -1,0 z"
-           id="rect4241" />
-        <path
-           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,17 1,0 0,1 -1,0 z"
-           id="rect4243" />
-        <path
-           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,17 1,0 0,1 -1,0 z"
-           id="rect4247" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,17 1,0 0,1 -1,0 z"
-           id="rect4249" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,17 1,0 0,1 -1,0 z"
-           id="rect4251" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,17 1,0 0,1 -1,0 z"
-           id="rect4253" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,17 1,0 0,1 -1,0 z"
-           id="rect4255" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,19 1,0 0,1 -1,0 z"
-           id="rect4287" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,19 1,0 0,1 -1,0 z"
-           id="rect4289" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,19 1,0 0,1 -1,0 z"
-           id="rect4291" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,19 1,0 0,1 -1,0 z"
-           id="rect4293" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,19 1,0 0,1 -1,0 z"
-           id="rect4295" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,19 1,0 0,1 -1,0 z"
-           id="rect4297" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,19 1,0 0,1 -1,0 z"
-           id="rect4299" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,19 1,0 0,1 -1,0 z"
-           id="rect4301" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,20 1,0 0,1 -1,0 z"
-           id="rect4305" />
-        <rect
-           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           id="rect4307"
-           width="1"
-           height="1"
-           x="14"
-           y="22" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,20 1,0 0,1 -1,0 z"
-           id="rect4309" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,20 1,0 0,1 -1,0 z"
-           id="rect4311" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,20 1,0 0,1 -1,0 z"
-           id="rect4313" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,20 1,0 0,1 -1,0 z"
-           id="rect4315" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,20 1,0 0,1 -1,0 z"
-           id="rect4317" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,22 1,0 0,1 -1,0 z"
-           id="rect4321" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,22 1,0 0,1 -1,0 z"
-           id="rect4323" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,20 1,0 0,1 -1,0 z"
-           id="rect4325" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,22 1,0 0,1 -1,0 z"
-           id="rect4327" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,22 1,0 0,1 -1,0 z"
-           id="rect4329" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,22 1,0 0,1 -1,0 z"
-           id="rect4331" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,21 1,0 0,1 -1,0 z"
-           id="rect4335" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,21 1,0 0,1 -1,0 z"
-           id="rect4337" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,21 1,0 0,1 -1,0 z"
-           id="rect4339" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,21 1,0 0,1 -1,0 z"
-           id="rect4341" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,21 1,0 0,1 -1,0 z"
-           id="rect4343" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,21 1,0 0,1 -1,0 z"
-           id="rect4345" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,21 1,0 0,1 -1,0 z"
-           id="rect4349" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,21 1,0 0,1 -1,0 z"
-           id="rect4351" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,22 1,0 0,1 -1,0 z"
-           id="rect4451" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,24 1,0 0,1 -1,0 z"
-           id="rect4455" />
-        <path
-           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,24 1,0 0,1 -1,0 z"
-           id="rect4457" />
-        <path
-           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,24 1,0 0,1 -1,0 z"
-           id="rect4459" />
-        <path
-           style="fill:#e5e5e5;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,24 1,0 0,1 -1,0 z"
-           id="rect4461" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,24 1,0 0,1 -1,0 z"
-           id="rect4463" />
-        <path
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,24 1,0 0,1 -1,0 z"
-           id="rect4465" />
-        <rect
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           id="rect4477"
-           width="1"
-           height="1"
-           x="31"
-           y="24" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,24 1,0 0,1 -1,0 z"
-           id="rect4483" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,23 1,0 0,1 -1,0 z"
-           id="rect4485" />
-        <path
-           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,23 1,0 0,1 -1,0 z"
-           id="rect4487" />
-        <path
-           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,23 1,0 0,1 -1,0 z"
-           id="rect4489" />
-        <path
-           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,23 1,0 0,1 -1,0 z"
-           id="rect4493" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,23 1,0 0,1 -1,0 z"
-           id="rect4495" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,23 1,0 0,1 -1,0 z"
-           id="rect4497" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,23 1,0 0,1 -1,0 z"
-           id="rect4499" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,23 1,0 0,1 -1,0 z"
-           id="rect4501" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,25 1,0 0,1 -1,0 z"
-           id="rect4533" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,25 1,0 0,1 -1,0 z"
-           id="rect4535" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,25 1,0 0,1 -1,0 z"
-           id="rect4537" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,25 1,0 0,1 -1,0 z"
-           id="rect4539" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,25 1,0 0,1 -1,0 z"
-           id="rect4541" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,25 1,0 0,1 -1,0 z"
-           id="rect4543" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,25 1,0 0,1 -1,0 z"
-           id="rect4545" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,25 1,0 0,1 -1,0 z"
-           id="rect4547" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,25 1,0 0,1 -1,0 z"
-           id="rect4549" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,26 1,0 0,1 -1,0 z"
-           id="rect4551" />
-        <rect
-           y="28"
-           x="14"
-           height="1"
-           width="1"
-           id="rect4553"
-           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,26 1,0 0,1 -1,0 z"
-           id="rect4555" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,26 1,0 0,1 -1,0 z"
-           id="rect4557" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,26 1,0 0,1 -1,0 z"
-           id="rect4559" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,26 1,0 0,1 -1,0 z"
-           id="rect4561" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,26 1,0 0,1 -1,0 z"
-           id="rect4563" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,28 1,0 0,1 -1,0 z"
-           id="rect4567" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,28 1,0 0,1 -1,0 z"
-           id="rect4569" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,26 1,0 0,1 -1,0 z"
-           id="rect4571" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,28 1,0 0,1 -1,0 z"
-           id="rect4573" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,28 1,0 0,1 -1,0 z"
-           id="rect4575" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,28 1,0 0,1 -1,0 z"
-           id="rect4577" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,27 1,0 0,1 -1,0 z"
-           id="rect4581" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,27 1,0 0,1 -1,0 z"
-           id="rect4583" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,27 1,0 0,1 -1,0 z"
-           id="rect4585" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,27 1,0 0,1 -1,0 z"
-           id="rect4587" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,27 1,0 0,1 -1,0 z"
-           id="rect4589" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,27 1,0 0,1 -1,0 z"
-           id="rect4591" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,27 1,0 0,1 -1,0 z"
-           id="rect4597" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,26 1,0 0,1 -1,0 z"
-           id="rect4621" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,28 1,0 0,1 -1,0 z"
-           id="rect4633" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,28 1,0 0,1 -1,0 z"
-           id="rect4635" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,27 1,0 0,1 -1,0 z"
-           id="rect4641" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,27 1,0 0,1 -1,0 z"
-           id="rect4647" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,26 1,0 0,1 -1,0 z"
-           id="rect4661" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,26 1,0 0,1 -1,0 z"
-           id="rect4673" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,27 1,0 0,1 -1,0 z"
-           id="rect4675" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,25 1,0 0,1 -1,0 z"
-           id="rect4681" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,26 1,0 0,1 -1,0 z"
-           id="rect4683" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,28 1,0 0,1 -1,0 z"
-           id="rect4685" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,27 1,0 0,1 -1,0 z"
-           id="rect4687" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,27 1,0 0,1 -1,0 z"
-           id="rect4689" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,28 1,0 0,1 -1,0 z"
-           id="rect4691" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,28 1,0 0,1 -1,0 z"
-           id="rect4693" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,28 1,0 0,1 -1,0 z"
-           id="rect4695" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,28 1,0 0,1 -1,0 z"
-           id="rect4697" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,26 1,0 0,1 -1,0 z"
-           id="rect4699" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,30 1,0 0,1 -1,0 z"
-           id="rect4701" />
-        <path
-           style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,30 1,0 0,1 -1,0 z"
-           id="rect4703" />
-        <path
-           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,30 1,0 0,1 -1,0 z"
-           id="rect4705" />
-        <path
-           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,30 1,0 0,1 -1,0 z"
-           id="rect4709" />
-        <path
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,30 1,0 0,1 -1,0 z"
-           id="rect4711" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,30 1,0 0,1 -1,0 z"
-           id="rect4713" />
-        <path
-           style="fill:#eaeaea;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,30 1,0 0,1 -1,0 z"
-           id="rect4715" />
-        <path
-           style="fill:#e2e2e2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,30 1,0 0,1 -1,0 z"
-           id="rect4717" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,30 1,0 0,1 -1,0 z"
-           id="rect4719" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 27,30 1,0 0,1 -1,0 z"
-           id="rect4721" />
-        <rect
-           y="30"
-           x="31"
-           height="1"
-           width="1"
-           id="rect4723"
-           style="fill:#f1f1f1;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,30 1,0 0,1 -1,0 z"
-           id="rect4725" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,30 1,0 0,1 -1,0 z"
-           id="rect4727" />
-        <path
-           style="fill:#e9e9e9;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,30 1,0 0,1 -1,0 z"
-           id="rect4729" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,29 1,0 0,1 -1,0 z"
-           id="rect4731" />
-        <path
-           style="fill:#b7b7b7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,29 1,0 0,1 -1,0 z"
-           id="rect4733" />
-        <path
-           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,29 1,0 0,1 -1,0 z"
-           id="rect4737" />
-        <path
-           style="fill:#b0b0b0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,29 1,0 0,1 -1,0 z"
-           id="rect4739" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,29 1,0 0,1 -1,0 z"
-           id="rect4741" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,29 1,0 0,1 -1,0 z"
-           id="rect4743" />
-        <path
-           style="fill:#b2b2b2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,29 1,0 0,1 -1,0 z"
-           id="rect4749" />
-        <path
-           style="fill:#b2b2b2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,29 1,0 0,1 -1,0 z"
-           id="rect4751" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 24,29 1,0 0,1 -1,0 z"
-           id="rect4753" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,29 1,0 0,1 -1,0 z"
-           id="rect4755" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,29 1,0 0,1 -1,0 z"
-           id="rect4757" />
-        <path
-           style="fill:#b1b1b1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 29,29 1,0 0,1 -1,0 z"
-           id="rect4759" />
-        <path
-           style="fill:#b1b1b1;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 32,29 1,0 0,1 -1,0 z"
-           id="rect4761" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 26,29 1,0 0,1 -1,0 z"
-           id="rect4763" />
-        <path
-           style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 27,29 1,0 0,1 -1,0 z"
-           id="rect4765" />
-        <path
-           style="fill:#cacaca;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,29 1,0 0,1 -1,0 z"
-           id="rect4767" />
-        <path
-           style="fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,29 1,0 0,1 -1,0 z"
-           id="rect4769" />
-        <path
-           style="fill:#c5c5c5;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,29 1,0 0,1 -1,0 z"
-           id="rect4771" />
-        <path
-           style="fill:#c2c2c2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,29 1,0 0,1 -1,0 z"
-           id="rect4773" />
-        <path
-           style="fill:#c7c7c7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,29 1,0 0,1 -1,0 z"
-           id="rect4775" />
-        <path
-           style="fill:#c7c7c7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,29 1,0 0,1 -1,0 z"
-           id="rect4777" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,31 1,0 0,1 -1,0 z"
-           id="rect4779" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,31 1,0 0,1 -1,0 z"
-           id="rect4781" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,31 1,0 0,1 -1,0 z"
-           id="rect4783" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,31 1,0 0,1 -1,0 z"
-           id="rect4791" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,31 1,0 0,1 -1,0 z"
-           id="rect4793" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,31 1,0 0,1 -1,0 z"
-           id="rect4795" />
-        <rect
-           y="32"
-           x="12"
-           height="1"
-           width="1"
-           id="rect4797"
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none" />
-        <rect
-           style="fill:#dcdcdc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           id="rect4799"
-           width="1"
-           height="1"
-           x="14"
-           y="34" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,32 1,0 0,1 -1,0 z"
-           id="rect4803" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,32 1,0 0,1 -1,0 z"
-           id="rect4807" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,32 1,0 0,1 -1,0 z"
-           id="rect4809" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,32 1,0 0,1 -1,0 z"
-           id="rect4811" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,34 1,0 0,1 -1,0 z"
-           id="rect4813" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 14,34 1,0 0,1 -1,0 z"
-           id="rect4815" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 13,32 1,0 0,1 -1,0 z"
-           id="rect4817" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,34 1,0 0,1 -1,0 z"
-           id="rect4819" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 15,34 1,0 0,1 -1,0 z"
-           id="rect4823" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,34 1,0 0,1 -1,0 z"
-           id="rect4825" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 16,33 1,0 0,1 -1,0 z"
-           id="rect4827" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 18,33 1,0 0,1 -1,0 z"
-           id="rect4829" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 12,33 1,0 0,1 -1,0 z"
-           id="rect4833" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 20,33 1,0 0,1 -1,0 z"
-           id="rect4839" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 19,33 1,0 0,1 -1,0 z"
-           id="rect4841" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 17,33 1,0 0,1 -1,0 z"
-           id="rect4843" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,31 1,0 0,1 -1,0 z"
-           id="rect4845" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,31 1,0 0,1 -1,0 z"
-           id="rect4847" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,31 1,0 0,1 -1,0 z"
-           id="rect4849" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 24,31 1,0 0,1 -1,0 z"
-           id="rect4851" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,31 1,0 0,1 -1,0 z"
-           id="rect4853" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 26,31 1,0 0,1 -1,0 z"
-           id="rect4855" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 27,31 1,0 0,1 -1,0 z"
-           id="rect4857" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,31 1,0 0,1 -1,0 z"
-           id="rect4859" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 29,31 1,0 0,1 -1,0 z"
-           id="rect4861" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,32 1,0 0,1 -1,0 z"
-           id="rect4863" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,32 1,0 0,1 -1,0 z"
-           id="rect4865" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,32 1,0 0,1 -1,0 z"
-           id="rect4867" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 24,32 1,0 0,1 -1,0 z"
-           id="rect4869" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 27,32 1,0 0,1 -1,0 z"
-           id="rect4871" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,32 1,0 0,1 -1,0 z"
-           id="rect4873" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 29,32 1,0 0,1 -1,0 z"
-           id="rect4875" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,32 1,0 0,1 -1,0 z"
-           id="rect4877" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,34 1,0 0,1 -1,0 z"
-           id="rect4879" />
-        <path
-           style="fill:#dedede;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,34 1,0 0,1 -1,0 z"
-           id="rect4881" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 25,33 1,0 0,1 -1,0 z"
-           id="rect4883" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 27,33 1,0 0,1 -1,0 z"
-           id="rect4885" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 22,33 1,0 0,1 -1,0 z"
-           id="rect4887" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 21,33 1,0 0,1 -1,0 z"
-           id="rect4889" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 24,33 1,0 0,1 -1,0 z"
-           id="rect4891" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 23,33 1,0 0,1 -1,0 z"
-           id="rect4893" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 29,33 1,0 0,1 -1,0 z"
-           id="rect4895" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,33 1,0 0,1 -1,0 z"
-           id="rect4897" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 26,33 1,0 0,1 -1,0 z"
-           id="rect4899" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,31 1,0 0,1 -1,0 z"
-           id="rect4901" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,31 1,0 0,1 -1,0 z"
-           id="rect4903" />
-        <path
-           style="fill:#e3e3e3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,32 1,0 0,1 -1,0 z"
-           id="rect4905" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,32 1,0 0,1 -1,0 z"
-           id="rect4907" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,33 1,0 0,1 -1,0 z"
-           id="rect4909" />
-        <path
-           style="fill:#d0d0d0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,33 1,0 0,1 -1,0 z"
-           id="rect4911" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 32,31 1,0 0,1 -1,0 z"
-           id="rect4913" />
-        <path
-           style="fill:#d2d2d2;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,31 1,0 0,1 -1,0 z"
-           id="rect4915" />
-        <path
-           style="fill:#e7e7e7;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 32,32 1,0 0,1 -1,0 z"
-           id="rect4917" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,32 1,0 0,1 -1,0 z"
-           id="rect4919" />
-        <path
-           style="fill:#c3c3c3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 33,33 1,0 0,1 -1,0 z"
-           id="rect4921" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 32,33 1,0 0,1 -1,0 z"
-           id="rect4923" />
-        <path
-           style="fill:#d3d3d3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,31 1,0 0,1 -1,0 z"
-           id="rect4925" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,31 1,0 0,1 -1,0 z"
-           id="rect4927" />
-        <path
-           style="fill:#ededed;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,32 1,0 0,1 -1,0 z"
-           id="rect4929" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,34 1,0 0,1 -1,0 z"
-           id="rect4931" />
-        <path
-           style="fill:#b3b3b3;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 34,33 1,0 0,1 -1,0 z"
-           id="rect4933" />
-        <path
-           style="fill:#c8c8c8;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,33 1,0 0,1 -1,0 z"
-           id="rect4935" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 31,34 1,0 0,1 -1,0 z"
-           id="rect4937" />
-        <path
-           style="fill:#e6e6e6;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 28,34 1,0 0,1 -1,0 z"
-           id="rect4939" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 30,34 1,0 0,1 -1,0 z"
-           id="rect4941" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,34 1,0 0,1 -1,0 z"
-           id="rect4943" />
-        <path
-           style="fill:#efefef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-           d="m 35,32 1,0 0,1 -1,0 z"
-           id="rect4945" />
-      </g>
-      <g
-         id="g5126">
-        <g
-           id="g3257">
+           transform="translate(-39,-5.9999999)"
+           id="g3606">
           <g
-             transform="translate(0,-0.004)"
-             id="g35">
+             id="g61-6"
+             transform="translate(39,6.9999999)">
             <g
-               clip-path="url(#clipPath-442087651-1)"
-               id="g37">
-              <g
-                 transform="translate(1,1)"
-                 id="g39">
-                <g
-                   style="opacity:0.1"
-                   id="g41">
-                  <!-- color: #cccdb6 -->
-                  <g
-                     id="g43" />
-                </g>
-              </g>
+               transform="translate(1,-2)"
+               id="g3858">
+              <path
+                 sodipodi:nodetypes="ccccccccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5098"
+                 d="m 11,13 0,23.84375 C 23.282855,31.63663 15.528737,13.185727 28,13 z m 17,0 c 2.305128,0 4.616902,0.902441 6.375,2.65625 C 36.129098,17.409555 37,19.69709 37,22 l 0,-9 z m 9,9 c 0,2.30291 -0.870902,4.621194 -2.625,6.375 -12.873922,2.440017 -9.468361,-1.686844 -16.28125,5.6875 L 13.15625,39 37,39 z M 13.15625,39 11,36.84375 11,39 z"
+                 style="fill:#000000;fill-opacity:0.11952192;fill-rule:evenodd;stroke:none" />
             </g>
           </g>
-          <g
-             id="g3251">
-            <path
-               inkscape:connector-curvature="0"
-               id="path5108"
-               d="m 29,12 c -2.309128,0 -4.620902,0.902442 -6.375,2.65625 -3.255111,3.250858 -3.466079,8.378689 -0.6875,11.90625 L 17.25,31.21875 16.9375,30.90625 12,35.84375 14.15625,38 19.09375,33.0625 18.75,32.75 23.40625,28.09375 c 3.529423,2.789485 8.709198,2.537473 11.96875,-0.71875 3.508195,-3.507613 3.508195,-9.21214 0,-12.71875 C 33.616902,12.902441 31.305128,12 29,12 z m 0,1.46875 c 1.922107,0 3.839419,0.746913 5.3125,2.21875 2.941164,2.940673 2.941164,7.684327 0,10.625 -2.945163,2.940672 -7.711087,2.940672 -10.65625,0 -2.941164,-2.940673 -2.941164,-7.684327 0,-10.625 C 25.129332,14.21466 27.074893,13.46875 29,13.46875 z"
-               style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none" />
-            <path
-               style="fill:#f5efef;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="m 36.602,19.898 c 0,4.69679 -3.805,8.5 -8.5,8.5 -4.699,0 -8.504,-3.80321 -8.5,-8.5 -0.004,-4.692792 3.801,-8.5 8.5,-8.5 4.695,0 8.5,3.807208 8.5,8.5 m 0,0"
-               id="path63" />
-            <path
-               sodipodi:nodetypes="cccc"
-               style="fill:#d24c37;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="m 22.622,26.866 -1.504,-1.504 -4.934,4.934 1.504,1.504"
-               id="path69-5" />
-            <path
-               style="fill:#b19b9b;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="m 27.986499,11.000001 c -2.309128,0 -4.598255,0.8869 -6.352353,2.640708 -3.512195,3.507606 -3.512195,9.221973 0,12.728584 3.508195,3.507609 9.223513,3.507609 12.734708,0 3.508195,-3.507613 3.508195,-9.221974 0,-12.728584 C 32.610756,11.8869 30.290627,11 27.985499,11 m 0,1.479833 c 1.922107,0 3.840214,0.726923 5.313295,2.19876 2.941164,2.940673 2.941164,7.679146 0,10.619819 -2.945163,2.940672 -7.684427,2.940672 -10.62959,0 -2.941164,-2.940673 -2.941164,-7.679146 0,-10.619819 1.473082,-1.47284 3.391188,-2.19876 5.316295,-2.19876 m 0,0"
-               id="path65" />
-            <path
-               sodipodi:nodetypes="cccc"
-               style="fill:#222b30;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="M 18.079,32.066 15.934,29.921 11,34.855 13.145,37"
-               id="path67" />
-          </g>
         </g>
         <g
-           id="text5091"
-           style="font-size:19.6648159px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
-           transform="scale(0.96219942,1.0392856)">
-          <path
-             sodipodi:nodetypes="cccccccccccc"
-             inkscape:connector-curvature="0"
-             id="path5096"
-             style="font-size:13.76537228px;font-weight:bold;fill:#606060;-inkscape-font-specification:Montserrat Bold"
-             d="m 32.011372,23.092789 -0.832804,-1.924402 -4.157142,0 -0.832806,1.924402 -2.285052,0 4.157143,-9.621996 2.078571,0 4.157142,9.621996 -2.285052,0 m -2.911375,-6.735399 -1.247143,2.886598 2.494285,0" />
+           id="g5601">
+          <g
+             id="g5145">
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:#f5efef;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path67-3"
+               d="m 37,11 -26,0 0,26 26,0"
+               sodipodi:nodetypes="cccc" />
+          </g>
+          <g
+             id="g5126">
+            <g
+               id="g3257">
+              <g
+                 transform="translate(0,-0.004)"
+                 id="g35">
+                <g
+                   clip-path="url(#clipPath-442087651-1)"
+                   id="g37">
+                  <g
+                     transform="translate(1,1)"
+                     id="g39">
+                    <g
+                       style="opacity:0.1"
+                       id="g41">
+                      <!-- color: #cccdb6 -->
+                      <g
+                         id="g43" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g
+                 id="g3251" />
+            </g>
+            <g
+               id="text5091"
+               style="font-size:19.6648159px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+               transform="scale(0.96219942,1.0392856)" />
+          </g>
         </g>
       </g>
+      <path
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,13 24,0 0,1 -24,0 z"
+         id="rect3285" />
+      <path
+         id="path4060"
+         d="m 12,15 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,17 24,0 0,1 -24,0 z"
+         id="path4062" />
+      <path
+         id="path4064"
+         d="m 12,19 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,21 24,0 0,1 -24,0 z"
+         id="path4066" />
+      <path
+         id="path4068"
+         d="m 12,23 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,25 24,0 0,1 -24,0 z"
+         id="path4070" />
+      <path
+         id="path4072"
+         d="m 12,27 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,29 24,0 0,1 -24,0 z"
+         id="path4074" />
+      <path
+         id="path4076"
+         d="m 12,31 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,33 24,0 0,1 -24,0 z"
+         id="path4078" />
     </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path5108"
+       d="m 29,12 c -2.309128,0 -4.620902,0.902442 -6.375,2.65625 -3.255111,3.250858 -3.466079,8.378689 -0.6875,11.90625 L 17.25,31.21875 16.9375,30.90625 12,35.84375 14.15625,38 19.09375,33.0625 18.75,32.75 23.40625,28.09375 c 3.529423,2.789485 8.709198,2.537473 11.96875,-0.71875 3.508195,-3.507613 3.508195,-9.21214 0,-12.71875 C 33.616902,12.902441 31.305128,12 29,12 z m 0,1.46875 c 1.922107,0 3.839419,0.746913 5.3125,2.21875 2.941164,2.940673 2.941164,7.684327 0,10.625 -2.945163,2.940672 -7.711087,2.940672 -10.65625,0 -2.941164,-2.940673 -2.941164,-7.684327 0,-10.625 C 25.129332,14.21466 27.074893,13.46875 29,13.46875 z"
+       style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none" />
+    <path
+       style="fill:#f5efef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 36.602,19.898 c 0,4.69679 -3.805,8.5 -8.5,8.5 -4.699,0 -8.504,-3.80321 -8.5,-8.5 -0.004,-4.692792 3.801,-8.5 8.5,-8.5 4.695,0 8.5,3.807208 8.5,8.5 m 0,0"
+       id="path63" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#d24c37;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 22.622,26.866 -1.504,-1.504 -4.934,4.934 1.504,1.504"
+       id="path69-5" />
+    <path
+       style="fill:#b19b9b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 27.986499,11.000001 c -2.309128,0 -4.598255,0.8869 -6.352353,2.640708 -3.512195,3.507606 -3.512195,9.221973 0,12.728584 3.508195,3.507609 9.223513,3.507609 12.734708,0 3.508195,-3.507613 3.508195,-9.221974 0,-12.728584 C 32.610756,11.8869 30.290627,11 27.985499,11 m 0,1.479833 c 1.922107,0 3.840214,0.726923 5.313295,2.19876 2.941164,2.940673 2.941164,7.679146 0,10.619819 -2.945163,2.940672 -7.684427,2.940672 -10.62959,0 -2.941164,-2.940673 -2.941164,-7.679146 0,-10.619819 1.473082,-1.47284 3.391188,-2.19876 5.316295,-2.19876 m 0,0"
+       id="path65" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#222b30;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="M 18.079,32.066 15.934,29.921 11,34.855 13.145,37"
+       id="path67" />
+    <path
+       sodipodi:nodetypes="cccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path5096"
+       style="font-size:13.76537228px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat Bold"
+       d="M 30.801324,24.000003 30,22 l -4,0 -0.801325,2.000003 -2.198676,0 L 27,14.000001 l 2,0 3.999999,10.000002 -2.198675,0 M 28,17 l -1.2,3 2.4,0" />
   </g>
 </svg>


### PR DESCRIPTION
Icon for YAGF, issue #1103
![yagf](https://cloud.githubusercontent.com/assets/7050624/5957738/5b15a1e8-a7bd-11e4-9dd4-445b2de6e0aa.png)

Or the lighter alternative:
![yagf2](https://cloud.githubusercontent.com/assets/7050624/5958545/d4638e86-a7c5-11e4-9f34-7bca93ed26c5.png)

