### PR TITLE
Icon for Notepadqq. Fixes #1537

### DIFF
--- a/Numix-Circle/48x48/apps/notepadqq.svg
+++ b/Numix-Circle/48x48/apps/notepadqq.svg
@@ -1,0 +1,217 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="notepadqq4.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="11.036083"
+     inkscape:cy="21.543583"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="false"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#008947;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#009c51;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g3940" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g5337"
+     transform="matrix(3.543307,0,0,3.543307,-8.9638233e-8,-9.0000005)">
+    <path
+       inkscape:connector-curvature="0"
+       id="rect5261"
+       d="m 4.7977779,3.6688888 c -0.3127022,0 -0.5644444,0.2517422 -0.5644444,0.5644444 l -0.4145139,0 c -0.0831,0 -0.1499306,0.06683 -0.1499306,0.1499306 l 0,0.2645833 c 0,0.0831 0.066831,0.1499306 0.1499306,0.1499306 l 0.4145139,0 0,0.5644444 -0.4145139,0 c -0.0831,0 -0.1499306,0.066831 -0.1499306,0.1499306 l 0,0.2645833 c 0,0.0831 0.066831,0.1499306 0.1499306,0.1499306 l 0.4145139,0 0,0.5644445 -0.4145139,0 c -0.0831,0 -0.1499306,0.066831 -0.1499306,0.1499305 l 0,0.2645834 c 0,0.0831 0.066831,0.1499305 0.1499306,0.1499305 l 0.4145139,0 0,0.5644445 -0.4145139,0 c -0.0831,0 -0.1499306,0.066831 -0.1499306,0.1499305 l 0,0.2645834 c 0,0.0831 0.066831,0.1499305 0.1499306,0.1499305 l 0.4145139,0 0,0.5644445 -0.4145139,0 c -0.0831,0 -0.1499306,0.066831 -0.1499306,0.1499306 l 0,0.2645833 c 0,0.0831 0.066831,0.1499306 0.1499306,0.1499306 l 0.4145139,0 0,0.5644444 -0.4145139,0 c -0.0831,0 -0.1499306,0.066831 -0.1499306,0.1499302 l 0,0.264584 c 0,0.0831 0.066831,0.14993 0.1499306,0.14993 l 0.4145139,0 c 0,0.312703 0.2517422,0.564445 0.5644444,0.564445 l 5.0800002,0 c 0.3127019,0 0.5644449,-0.251742 0.5644449,-0.564445 l 0,-6.2088888 c 0,-0.3127022 -0.251743,-0.5644444 -0.5644449,-0.5644444 l -5.0800002,0 z"
+       style="opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       transform="translate(0,2.2577779)" />
+    <rect
+       ry="0.56444442"
+       rx="0.56444442"
+       y="3.3866668"
+       x="3.9511113"
+       height="7.3377781"
+       width="6.208889"
+       id="rect5239"
+       style="opacity:1;fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       transform="translate(0,2.2577779)" />
+    <path
+       style="opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 7.3171697,3.9544187 A 1.4111112,1.4111112 0 0 0 6.3398652,4.36783 a 1.4111112,1.4111112 0 0 0 0,1.9953995 1.4111112,1.4111112 0 0 0 1.7743619,0.1780424 L 8.5348046,6.9618493 8.9338844,6.5627693 8.5144095,6.1432945 A 1.4111112,1.4111112 0 0 0 8.3352644,4.36783 1.4111112,1.4111112 0 0 0 7.3171697,3.9544187 Z m 0.032522,0.5644445 A 0.84666669,0.84666669 0 0 1 7.9361848,4.76691 0.84666669,0.84666669 0 0 1 8.100998,5.729883 L 7.7366445,5.3655299 7.3375648,5.7646096 7.7019182,6.128963 a 0.84666669,0.84666669 0 0 1 -0.9629733,-0.1648135 0.84666669,0.84666669 0 0 1 0,-1.1972395 0.84666669,0.84666669 0 0 1 0.6107467,-0.2480468 z"
+       id="path4262"
+       inkscape:connector-curvature="0"
+       transform="translate(0,2.2577779)" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path5237"
+       d="m 7.3171697,7.3410855 a 1.4111112,1.4111112 0 0 0 -0.9773045,0.4134113 1.4111112,1.4111112 0 0 0 0,1.9953995 1.4111112,1.4111112 0 0 0 1.7743619,0.1780424 L 8.5348046,10.348516 8.9338844,9.9494361 8.5144095,9.5299613 A 1.4111112,1.4111112 0 0 0 8.3352644,7.7544968 1.4111112,1.4111112 0 0 0 7.3171697,7.3410855 Z M 7.3496917,7.90553 A 0.84666669,0.84666669 0 0 1 7.9361848,8.1535768 0.84666669,0.84666669 0 0 1 8.100998,9.1165498 L 7.7366445,8.7521967 7.3375648,9.1512764 7.7019182,9.5156298 a 0.84666669,0.84666669 0 0 1 -0.9629733,-0.1648135 0.84666669,0.84666669 0 0 1 0,-1.1972395 A 0.84666669,0.84666669 0 0 1 7.3496916,7.90553 Z"
+       style="opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       transform="translate(0,2.2577779)" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#b1c9c9;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 4.5155557,5.6444439 c -0.3127023,0 -0.5644445,0.2517423 -0.5644445,0.5644445 l 0,6.2088896 c 0,0.312702 0.2517422,0.564445 0.5644445,0.564445 l 0.5644444,0 0,-7.3377791 -0.5644444,0 z"
+       id="rect5239-7" />
+    <rect
+       style="fill:#81584a;fill-opacity:1;stroke:none"
+       id="rect4116"
+       width="1.1288887"
+       height="0.56444448"
+       x="3.3866668"
+       y="8.4666653"
+       rx="0.15000001"
+       ry="0.15000001" />
+    <rect
+       ry="0.15000001"
+       rx="0.15000001"
+       y="9.5955544"
+       x="3.3866668"
+       height="0.56444448"
+       width="1.1288887"
+       id="rect4118"
+       style="fill:#81584a;fill-opacity:1;stroke:none" />
+    <rect
+       style="fill:#81584a;fill-opacity:1;stroke:none"
+       id="rect4120"
+       width="1.1288887"
+       height="0.56444448"
+       x="3.3866668"
+       y="10.724443"
+       rx="0.15000001"
+       ry="0.15000001" />
+    <rect
+       ry="0.15000001"
+       rx="0.15000001"
+       y="11.853333"
+       x="3.3866668"
+       height="0.56444448"
+       width="1.1288887"
+       id="rect4122"
+       style="fill:#81584a;fill-opacity:1;stroke:none" />
+    <rect
+       ry="0.15000001"
+       rx="0.15000001"
+       y="7.3377762"
+       x="3.3866668"
+       height="0.56444448"
+       width="1.1288887"
+       id="rect4114"
+       style="fill:#81584a;fill-opacity:1;stroke:none" />
+    <rect
+       style="fill:#81584a;fill-opacity:1;stroke:none"
+       id="rect5241"
+       width="1.1288887"
+       height="0.56444448"
+       x="3.3866668"
+       y="6.2088885"
+       rx="0.15000001"
+       ry="0.15000001" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Notepadqq, issue #1537

Pushed:
![notepadqq](https://cloud.githubusercontent.com/assets/7050624/6003188/de471e90-aaf9-11e4-9735-1ef4d489682e.png)
Alt:
![notepadqq0](https://cloud.githubusercontent.com/assets/7050624/6003194/e750e502-aaf9-11e4-9e15-56e0a7ab03d5.png)

