### PR TITLE
Icon for GNOME Color Chooser (symlink). Fixes #1553

### DIFF
--- a/Numix-Circle/48x48/apps/gnome-color-chooser.svg
+++ b/Numix-Circle/48x48/apps/gnome-color-chooser.svg
@@ -1,0 +1,1 @@
+preferences-color.svg


### PR DESCRIPTION
Symlink to *preferences-color.svg*