### PR TITLE
Icon for SciDAVis (symlink). Fixes #1571

### DIFF
--- a/Numix-Circle/48x48/apps/scidavis.svg
+++ b/Numix-Circle/48x48/apps/scidavis.svg
@@ -1,0 +1,1 @@
+qtiplot.svg


### PR DESCRIPTION
Symlink to the existing QtiPlot icon.