### PR TITLE
Icon for UFRaw. Fixes #1570

### DIFF
--- a/Numix-Circle/48x48/apps/ufraw.svg
+++ b/Numix-Circle/48x48/apps/ufraw.svg
@@ -9,19 +9,19 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
-   id="svg2"
+   id="svg4156"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="ufraw3.svg">
+   sodipodi:docname="ufraw5.svg">
   <metadata
-     id="metadata69">
+     id="metadata4255">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -36,17 +36,17 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1366"
      inkscape:window-height="713"
-     id="namedview67"
+     id="namedview4253"
      showgrid="false"
-     inkscape:zoom="5.6568542"
-     inkscape:cx="2.940678"
-     inkscape:cy="24"
+     inkscape:zoom="1"
+     inkscape:cx="17.00762"
+     inkscape:cy="23.974576"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
+     inkscape:current-layer="svg4156" />
   <defs
-     id="defs4">
+     id="defs4158">
     <linearGradient
        id="linearGradient3764"
        x1="1"
@@ -54,15 +54,39 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
       <stop
-         stop-color="#182f40"
+         stop-color="#3d505b"
          stop-opacity="1"
-         id="stop7" />
+         id="stop4161" />
       <stop
          offset="1"
-         stop-color="#1d394e"
+         stop-color="#455b68"
          stop-opacity="1"
-         id="stop9" />
+         id="stop4163" />
     </linearGradient>
+    <clipPath
+       id="clipPath-700949347">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g4166">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path4168" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-708417192">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g4171">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path4173" />
+      </g>
+    </clipPath>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4300"
@@ -98,36 +122,36 @@
     </linearGradient>
   </defs>
   <g
-     id="g21">
+     id="g4175">
     <path
        d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
        opacity="0.05"
-       id="path23" />
+       id="path4177" />
     <path
        d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
        opacity="0.1"
-       id="path25" />
+       id="path4179" />
     <path
        d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
        opacity="0.2"
-       id="path27" />
+       id="path4181" />
   </g>
   <g
-     id="g29">
+     id="g4183">
     <path
        d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
        fill="url(#linearGradient3764)"
        fill-opacity="1"
-       id="path31" />
+       id="path4185" />
   </g>
   <g
-     id="g33" />
+     id="g4187" />
   <g
-     id="g63">
+     id="g4249">
     <path
        d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
        opacity="0.1"
-       id="path65" />
+       id="path4251" />
   </g>
   <g
      id="g4161">
@@ -161,7 +185,7 @@
        id="g4235">
       <path
          transform="translate(0,-3)"
-         style="opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         style="opacity:1;fill:#787878;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
          d="m 36,22.9 c 0,1.656854 -5.372583,3.1 -12,3.1 -6.627417,0 -12,-1.443146 -12,-3.1 0,-1.656854 5.372583,-3.5 12,-3.5 6.627417,0 12,1.843146 12,3.5 z"
          id="path4199"
          inkscape:connector-curvature="0"

--- a/Numix-Circle/48x48/apps/ufraw.svg
+++ b/Numix-Circle/48x48/apps/ufraw.svg
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="ufraw3.svg">
+  <metadata
+     id="metadata69">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview67"
+     showgrid="false"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="2.940678"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#182f40"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#1d394e"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4300"
+       id="linearGradient4306"
+       x1="19.397747"
+       y1="29"
+       x2="28.513865"
+       y2="29"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4300">
+      <stop
+         style="stop-color:#87b2e3;stop-opacity:0.87058824"
+         offset="0"
+         id="stop4302" />
+      <stop
+         id="stop4308"
+         offset="0.25"
+         style="stop-color:#87e18a;stop-opacity:0.87058824" />
+      <stop
+         style="stop-color:#f1f074;stop-opacity:0.87058824"
+         offset="0.50484794"
+         id="stop4310" />
+      <stop
+         id="stop4312"
+         offset="0.75"
+         style="stop-color:#ebb25a;stop-opacity:0.87058824" />
+      <stop
+         style="stop-color:#f17f51;stop-opacity:0.87058824"
+         offset="1"
+         id="stop4304" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g63">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path65" />
+  </g>
+  <g
+     id="g4161">
+    <g
+       transform="translate(0,-3)"
+       id="g4176">
+      <g
+         id="g4174">
+        <path
+           transform="translate(0,3.9999998)"
+           inkscape:connector-curvature="0"
+           id="path4528"
+           d="M 20.853516,24.837722 19,35.033034 c 1.001718,0.332207 2.001669,0.576345 3,0.736328 1.002127,0.160592 2.002465,0.234673 3,0.230469 1.00272,-0.0042 2.00311,-0.08813 3,-0.25 1.003508,-0.162943 2.003626,-0.403154 3,-0.716797 L 29.146484,24.837722 c -0.369945,0.03421 -0.762337,0.05582 -1.146484,0.08203 -0.9626,0.06567 -1.95378,0.113281 -3,0.113281 -1.046225,0 -2.0374,-0.04761 -3,-0.113281 -0.384147,-0.02621 -0.776539,-0.04782 -1.146484,-0.08203 z"
+           style="opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           sodipodi:nodetypes="ccscsccsssc" />
+        <path
+           transform="translate(0,3.9999998)"
+           sodipodi:nodetypes="cscccc"
+           inkscape:connector-curvature="0"
+           id="rect4292"
+           d="m 28.146484,23.836322 c -1.29696,0.119946 -2.682739,0.195 -4.146484,0.195 -1.463745,0 -2.849524,-0.07505 -4.146484,-0.195 L 18,34.031322 c 4.035473,1.338315 8.048201,1.243965 12,0 z"
+           style="opacity:1;fill:url(#linearGradient4306);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+        <path
+           style="opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+           d="m 25,17 c -2.557056,0 -4.374564,1.461269 -4.859375,3.748047 C 15.938981,21.35746 13,22.676821 13,23.900391 13,25.557245 18.372583,27 25,27 31.627417,27 37,25.557245 37,23.900391 37,22.676821 34.061019,21.35746 29.859375,20.748047 29.374564,18.461269 27.557056,17 25,17 Z"
+           id="path4167"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+    <g
+       id="g4235">
+      <path
+         transform="translate(0,-3)"
+         style="opacity:1;fill:#808080;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 36,22.9 c 0,1.656854 -5.372583,3.1 -12,3.1 -6.627417,0 -12,-1.443146 -12,-3.1 0,-1.656854 5.372583,-3.5 12,-3.5 6.627417,0 12,1.843146 12,3.5 z"
+         id="path4199"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssss" />
+      <path
+         transform="translate(0,-3)"
+         style="opacity:1;fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 29,21 c 0,1 -2.238576,1.9 -5,1.9 -2.761424,0 -5,-0.9 -5,-1.9 0,-3 2,-5 5,-5 3,0 5,2 5,5 z"
+         id="path4154"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssss" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for UFRaw. Fixes #1570

Pushed:
![ufraw](https://cloud.githubusercontent.com/assets/7050624/6178053/d7919674-b30b-11e4-927c-196fefab2274.png)
Alternatives:
![ufraw5](https://cloud.githubusercontent.com/assets/7050624/6178058/e0c1d4c0-b30b-11e4-872d-75892efcd19f.png)
![ufraw4b](https://cloud.githubusercontent.com/assets/7050624/6178065/e5cd30e0-b30b-11e4-8635-1a2a9282af35.png)


