### PR TITLE
Icons for several KDE games. Fixes #1578

### DIFF
--- a/Numix-Circle/48x48/apps/bovo.svg
+++ b/Numix-Circle/48x48/apps/bovo.svg
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="bovo2.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     showguides="false"
+     inkscape:zoom="1"
+     inkscape:cx="24.12264"
+     inkscape:cy="22.938447"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4193" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     id="g4265"
+     transform="translate(1,1)">
+    <g
+       id="g4267"
+       transform="translate(4,1)" />
+  </g>
+  <g
+     id="g4207">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4196"
+       d="m 24,12 0,12 -12,0 0,2 12,0 0,12 2,0 0,-12 12,0 0,-2 -12,0 0,-12 -2,0 z m 8,1 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -5,-5 z m -17.185547,0.408203 -1.414062,1.414063 3.18164,3.18164 -3.18164,3.181641 1.414062,1.414062 3.181641,-3.18164 3.18164,3.18164 1.414063,-1.414062 -3.181641,-3.181641 3.181641,-3.18164 -1.414063,-1.414063 -3.18164,3.181641 -3.181641,-3.181641 z M 32,15 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z M 18,27 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -5,-5 z m 10.814453,0.408203 -1.414062,1.414063 3.18164,3.18164 -3.18164,3.181641 1.414062,1.414062 3.181641,-3.18164 3.18164,3.18164 1.414063,-1.414062 -3.181641,-3.181641 3.181641,-3.18164 -1.414063,-1.414063 -3.18164,3.181641 -3.181641,-3.181641 z M 18,29 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       style="opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       id="rect4156"
+       d="M 23 11 L 23 23 L 11 23 L 11 25 L 23 25 L 23 37 L 25 37 L 25 25 L 37 25 L 37 23 L 25 23 L 25 11 L 23 11 z "
+       style="opacity:1;fill:#636363;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       id="path4160"
+       d="M 31 12 A 5 5 0 0 0 26 17 A 5 5 0 0 0 31 22 A 5 5 0 0 0 36 17 A 5 5 0 0 0 31 12 z M 31 14 A 3 3 0 0 1 34 17 A 3 3 0 0 1 31 20 A 3 3 0 0 1 28 17 A 3 3 0 0 1 31 14 z "
+       style="opacity:1;fill:#e67878;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#e67878;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 17,26 a 5,5 0 0 0 -5,5 5,5 0 0 0 5,5 5,5 0 0 0 5,-5 5,5 0 0 0 -5,-5 z m 0,2 a 3,3 0 0 1 3,3 3,3 0 0 1 -3,3 3,3 0 0 1 -3,-3 3,3 0 0 1 3,-3 z"
+       id="path4186" />
+    <path
+       id="rect4189"
+       d="M 13.814453 12.408203 L 12.400391 13.822266 L 15.582031 17.003906 L 12.400391 20.185547 L 13.814453 21.599609 L 16.996094 18.417969 L 20.177734 21.599609 L 21.591797 20.185547 L 18.410156 17.003906 L 21.591797 13.822266 L 20.177734 12.408203 L 16.996094 15.589844 L 13.814453 12.408203 z "
+       style="opacity:1;fill:#8484bc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       style="opacity:1;fill:#8484bc;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 27.814062,26.408594 26.4,27.822657 29.58164,31.004297 26.4,34.185938 27.814062,35.6 l 3.181641,-3.18164 3.18164,3.18164 1.414063,-1.414062 -3.181641,-3.181641 3.181641,-3.18164 -1.414063,-1.414063 -3.18164,3.181641 -3.181641,-3.181641 z"
+       id="path4194" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/katomic.svg
+++ b/Numix-Circle/48x48/apps/katomic.svg
@@ -1,0 +1,316 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="katomic3.svg">
+  <metadata
+     id="metadata73">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview71"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="23.812901"
+     inkscape:cy="24.75628"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3846" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4237">
+      <stop
+         style="stop-color:#dedede;stop-opacity:1"
+         offset="0"
+         id="stop4239" />
+      <stop
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         offset="1"
+         id="stop4241" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4213">
+      <stop
+         style="stop-color:#bfbfef;stop-opacity:1"
+         offset="0"
+         id="stop4215" />
+      <stop
+         style="stop-color:#a6a6ea;stop-opacity:1"
+         offset="1"
+         id="stop4217" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4241">
+      <stop
+         id="stop4243"
+         offset="0"
+         style="stop-color:#e99797;stop-opacity:1" />
+      <stop
+         id="stop4245"
+         offset="1"
+         style="stop-color:#e17373;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3836">
+      <stop
+         style="stop-color:#3a3a3a;stop-opacity:1;"
+         offset="0"
+         id="stop3838" />
+      <stop
+         style="stop-color:#303030;stop-opacity:1;"
+         offset="1"
+         id="stop3840" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3836"
+       id="linearGradient3844"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,1,-1,0,48,0)"
+       x1="1"
+       y1="24"
+       x2="47"
+       y2="24" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4241"
+       id="radialGradient3030"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.67550232,0,-5.0833709e-8,-1.1258375,39.536553,52.708853)"
+       cx="23"
+       cy="25.5"
+       fx="23"
+       fy="25.5"
+       r="13.323416" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4241"
+       id="radialGradient3032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-0.33775116,0.58500217,-0.9750039,-0.56291871,56.630874,24.899378)"
+       cx="23"
+       cy="25.5"
+       fx="23"
+       fy="25.5"
+       r="13.323416" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4241"
+       id="radialGradient3034"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.33775116,0.58077477,0.9750039,-0.5588509,-8.630874,24.892878)"
+       cx="23"
+       cy="25.5"
+       fx="23"
+       fy="25.5"
+       r="13.323416" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213"
+       id="radialGradient4219"
+       cx="27"
+       cy="22.75"
+       fx="27"
+       fy="22.75"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213"
+       id="radialGradient4227"
+       cx="24.75"
+       cy="26"
+       fx="24.75"
+       fy="26"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4213"
+       id="radialGradient4235"
+       cx="23"
+       cy="22.5"
+       fx="23"
+       fy="22.5"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4237"
+       id="radialGradient4243"
+       cx="26.75"
+       cy="25.25"
+       fx="26.75"
+       fy="25.25"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4237"
+       id="radialGradient4251"
+       cx="22.799999"
+       cy="25"
+       fx="22.799999"
+       fy="25"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4237"
+       id="radialGradient4259"
+       cx="24.75"
+       cy="22"
+       fx="24.75"
+       fy="22"
+       r="2.5"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3844);fill-opacity:1"
+     id="path31"
+     d="M 47,24 C 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 36.703,1 47,11.297 47,24 z" />
+  <g
+     id="g33" />
+  <g
+     id="g67">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path69" />
+  </g>
+  <g
+     transform="matrix(1,0,0,1.0001276,1,0.99693722)"
+     id="g3963"
+     style="fill:#000000;fill-opacity:0.11764706">
+    <g
+       id="g3979">
+      <g
+         id="g3986">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#000000;fill-opacity:0.11764706;stroke:none;stroke-width:0.64683139;marker:none;enable-background:accumulate"
+           d="M 30.398438 11.404297 C 30.160809 11.391577 29.922974 11.39332 29.6875 11.40625 C 29.373534 11.42342 29.05556 11.4501 28.75 11.5 C 27.52776 11.699604 26.264777 12.251979 25 13.0625 C 24.9809 13.07474 24.95658 13.08137 24.9375 13.09375 C 23.692799 12.310523 22.452929 11.820031 21.25 11.625 C 20.02776 11.426839 18.697993 11.406998 17.5 12.09375 C 16.302006 12.780502 15.65703 13.912443 15.21875 15.0625 C 14.783601 16.204342 14.590744 17.554029 14.65625 19.03125 C 13.32202 19.721458 12.22146 20.572427 11.4375 21.53125 C 10.653539 22.490027 10 23.6165 10 25 C 10 26.383501 10.653539 27.509926 11.4375 28.46875 C 12.22146 29.427573 13.32202 30.278542 14.65625 30.96875 C 14.655761 30.97878 14.656714 30.98998 14.65625 31 C 14.5868 32.500728 14.78047 33.841572 15.21875 35 C 15.65703 36.158429 16.302007 37.308251 17.5 38 C 18.697994 38.69175 20.02776 38.699604 21.25 38.5 C 22.47224 38.300396 23.735224 37.74802 25 36.9375 C 25.0191 36.92526 25.04342 36.91863 25.0625 36.90625 C 26.3072 37.689476 27.547071 38.179969 28.75 38.375 C 29.97224 38.573162 31.302006 38.593002 32.5 37.90625 C 33.697993 37.219499 34.34297 36.087558 34.78125 34.9375 C 35.216399 33.795658 35.409256 32.44597 35.34375 30.96875 C 36.677981 30.278542 37.77854 29.427573 38.5625 28.46875 C 39.34646 27.509926 40 26.383501 40 25 C 40 23.6165 39.34646 22.490074 38.5625 21.53125 C 37.77854 20.572427 36.677981 19.721458 35.34375 19.03125 C 35.344239 19.02122 35.343286 19.01002 35.34375 19 C 35.4132 17.499271 35.21953 16.158428 34.78125 15 C 34.34297 13.841572 33.697994 12.69175 32.5 12 C 31.826129 11.61089 31.111322 11.442448 30.398438 11.404297 z M 30.1875 12.5625 C 30.88816 12.57999 31.459547 12.804562 31.90625 13.0625 C 32.501854 13.406416 33.117872 13.95874 33.5 14.96875 C 33.876338 15.963456 34.119102 17.050172 34.0625 18.46875 C 32.675072 17.923219 31.09283 17.519473 29.375 17.28125 C 28.315955 15.948068 27.219054 14.808 26.0625 13.90625 C 27.285114 13.12275 28.371854 12.799029 29.4375 12.625 C 29.703912 12.58149 29.953947 12.55667 30.1875 12.5625 z M 19.8125 12.65625 C 20.046053 12.65045 20.296088 12.64431 20.5625 12.6875 C 21.592782 12.854538 22.639041 13.213734 23.8125 13.9375 C 22.683681 14.844843 21.596606 15.960899 20.5625 17.28125 C 18.868589 17.520188 17.308192 17.9298 15.9375 18.46875 C 15.8865 17.077686 16.126828 16.010459 16.5 15.03125 C 16.882128 14.028538 17.498146 13.466431 18.09375 13.125 C 18.540453 12.868929 19.11184 12.673617 19.8125 12.65625 z M 24.9375 14.71875 C 25.805894 15.385311 26.6691 16.169037 27.5 17.09375 C 26.685462 17.03388 25.854188 17 25 17 C 24.124 17 23.271644 17.03077 22.4375 17.09375 C 23.247947 16.178259 24.089924 15.387415 24.9375 14.71875 z M 25 18.3125 C 26.277172 18.3125 27.511498 18.38275 28.6875 18.53125 C 29.430677 19.494453 30.152189 20.551928 30.8125 21.6875 C 31.459361 22.799942 32.00581 23.901453 32.46875 25 C 32.004961 26.10988 31.461376 27.219721 30.8125 28.34375 C 30.162978 29.4689 29.44869 30.511367 28.71875 31.46875 C 27.533548 31.619807 26.288329 31.6875 25 31.6875 C 23.722827 31.6875 22.488466 31.61725 21.3125 31.46875 C 20.569342 30.50558 19.847811 29.448072 19.1875 28.3125 C 18.540639 27.200058 17.99419 26.098547 17.53125 25 C 17.995039 23.89012 18.538624 22.780279 19.1875 21.65625 C 19.837022 20.531101 20.551292 19.488665 21.28125 18.53125 C 22.466452 18.380193 23.711671 18.3125 25 18.3125 z M 19.40625 18.84375 C 18.942948 19.524503 18.493254 20.253817 18.0625 21 C 17.629018 21.750908 17.234602 22.503705 16.875 23.25 C 16.479572 22.067919 16.212342 20.928831 16.0625 19.84375 C 17.074661 19.433701 18.191814 19.093654 19.40625 18.84375 z M 30.53125 18.84375 C 31.768281 19.094952 32.908908 19.427045 33.9375 19.84375 C 33.784825 20.928881 33.518635 22.069598 33.125 23.25 C 32.765398 22.509097 32.370982 21.776732 31.9375 21.03125 C 31.492883 20.266618 31.010459 19.538992 30.53125 18.84375 z M 35.1875 20.375 C 36.462939 21.03923 37.258441 21.825724 37.9375 22.65625 C 38.621019 23.49223 38.8125 24.312168 38.8125 25 C 38.8125 25.687832 38.621019 26.50777 37.9375 27.34375 C 37.261148 28.170965 36.4543 28.931335 35.1875 29.59375 C 34.971597 28.136908 34.520033 26.588665 33.875 25 C 34.520453 23.39909 34.97151 21.84304 35.1875 20.375 z M 14.8125 20.40625 C 15.028403 21.863092 15.479967 23.411335 16.125 25 C 15.479547 26.60091 15.02849 28.15696 14.8125 29.625 C 13.537056 28.96077 12.74156 28.174276 12.0625 27.34375 C 11.378981 26.50777 11.1875 25.687832 11.1875 25 C 11.1875 24.312168 11.378981 23.49223 12.0625 22.65625 C 12.738853 21.829035 13.545699 21.068665 14.8125 20.40625 z M 24.951172 20.5 A 2.5 2.5 0 0 0 23.439453 21.011719 A 2.5 2.5 0 0 0 23.201172 21 A 2.5 2.5 0 0 0 20.701172 23.5 A 2.5 2.5 0 0 0 20.947266 24.576172 A 2.5 2.5 0 0 0 20.501953 26 A 2.5 2.5 0 0 0 22.951172 28.498047 A 2.5 2.5 0 0 0 24.951172 29.5 A 2.5 2.5 0 0 0 26.742188 28.740234 A 2.5 2.5 0 0 0 26.951172 28.75 A 2.5 2.5 0 0 0 29.451172 26.25 A 2.5 2.5 0 0 0 29.224609 25.214844 A 2.5 2.5 0 0 0 29.701172 23.75 A 2.5 2.5 0 0 0 27.201172 21.25 A 2.5 2.5 0 0 0 26.771484 21.289062 A 2.5 2.5 0 0 0 24.951172 20.5 z M 16.875 26.75 C 17.234602 27.490902 17.629018 28.223268 18.0625 28.96875 C 18.507117 29.733382 18.989541 30.461008 19.46875 31.15625 C 18.231764 30.905048 17.091069 30.572955 16.0625 30.15625 C 16.215175 29.071119 16.481365 27.930402 16.875 26.75 z M 33.125 26.75 C 33.520428 27.932081 33.787658 29.071169 33.9375 30.15625 C 32.925338 30.566299 31.808186 30.906346 30.59375 31.15625 C 31.057052 30.475496 31.506746 29.746183 31.9375 29 C 32.370982 28.249092 32.765398 27.496295 33.125 26.75 z M 15.9375 31.53125 C 17.324928 32.076781 18.90717 32.480527 20.625 32.71875 C 21.684046 34.051932 22.780945 35.192 23.9375 36.09375 C 22.714885 36.877251 21.628147 37.20097 20.5625 37.375 C 19.496853 37.54903 18.689354 37.28142 18.09375 36.9375 C 17.498146 36.593584 16.882128 36.04126 16.5 35.03125 C 16.123662 34.036543 15.880898 32.949829 15.9375 31.53125 z M 34.0625 31.53125 C 34.1135 32.922315 33.873172 33.98954 33.5 34.96875 C 33.117872 35.971462 32.501854 36.533568 31.90625 36.875 C 31.310646 37.216428 30.503147 37.485272 29.4375 37.3125 C 28.407217 37.145461 27.360967 36.786281 26.1875 36.0625 C 27.31632 35.155157 28.403394 34.039101 29.4375 32.71875 C 31.131411 32.479812 32.691808 32.0702 34.0625 31.53125 z M 22.5 32.90625 C 23.314539 32.96612 24.145812 33 25 33 C 25.875999 33 26.728357 32.96923 27.5625 32.90625 C 26.752075 33.821702 25.910064 34.612605 25.0625 35.28125 C 24.194117 34.614708 23.330877 33.830923 22.5 32.90625 z "
+           transform="matrix(1,0,0,0.99987242,-1,-0.99681003)"
+           id="path3965" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g4305">
+    <g
+       transform="matrix(1,0,0,1.0001276,0,-0.00306278)"
+       id="g3935">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3030);fill-opacity:1;stroke:none;stroke-width:0.64683139;marker:none;enable-background:accumulate"
+         d="m 24,16 c -4.030309,0 -7.683702,0.659941 -10.352164,2.040179 -1.33423,0.69012 -2.42277,1.518977 -3.20673,2.477678 C 9.6571454,21.476559 9,22.616677 9,24 c 0,1.383324 0.6571454,2.523441 1.441106,3.482143 0.78396,0.958701 1.8725,1.787558 3.20673,2.477678 C 16.316298,31.340059 19.969691,32 24,32 c 4.030308,0 7.683701,-0.659941 10.352163,-2.040179 1.334231,-0.69012 2.422771,-1.518977 3.206731,-2.477678 C 38.342854,26.523441 39,25.383324 39,24 39,22.616677 38.342854,21.476559 37.558894,20.517857 36.774934,19.559156 35.686394,18.730299 34.352163,18.040179 31.683701,16.659941 28.030308,16 24,16 Z m 0,1.3 c 3.97782,0 7.563522,0.745238 10.143029,2.079464 1.289752,0.667116 2.123453,1.440913 2.806971,2.276786 0.683519,0.835873 0.85,1.656006 0.85,2.34375 0,0.687744 -0.166481,1.507877 -0.85,2.34375 -0.683518,0.835873 -1.517219,1.60967 -2.806971,2.276786 C 31.563522,29.954762 27.97782,30.7 24,30.7 20.022179,30.7 16.436733,29.954762 13.857226,28.620536 12.567473,27.95342 11.733519,27.179623 11.05,26.34375 10.366481,25.507877 10.2,24.687744 10.2,24 c 0,-0.687744 0.166481,-1.507877 0.85,-2.34375 0.683519,-0.835873 1.517218,-1.60967 2.806971,-2.276786 C 16.436478,18.045238 20.022179,17.3 24,17.3 Z"
+         id="path3897"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssssssssssssssssssssssssss" />
+      <path
+         sodipodi:nodetypes="ssssssssssssssssssssssssss"
+         inkscape:connector-curvature="0"
+         id="path3909"
+         d="m 17.071797,20 c -2.015155,3.49035 -3.270326,6.984252 -3.409235,9.985327 -0.06945,1.500537 0.104087,2.857668 0.542367,4.015948 0.43828,1.158281 1.097078,2.297445 2.295071,2.989106 1.197994,0.691662 2.513937,0.692616 3.736177,0.493037 1.22224,-0.199579 2.484321,-0.727853 3.749097,-1.53827 C 26.514827,34.324311 28.913049,31.49035 30.928203,28 c 2.015154,-3.490349 3.270325,-6.984251 3.409235,-9.985326 0.06945,-1.500538 -0.104087,-2.857669 -0.542367,-4.015949 -0.43828,-1.15828 -1.097077,-2.297444 -2.295071,-2.989106 -1.197993,-0.691662 -2.513937,-0.692615 -3.736177,-0.493037 -1.22224,0.199579 -2.484321,0.727853 -3.749098,1.538271 C 21.485173,13.67569 19.086951,16.509651 17.071797,20 Z m 1.125833,0.65 c 1.98891,-3.444893 4.427156,-6.177583 6.872383,-7.744389 1.222614,-0.7834 2.309594,-1.118508 3.37524,-1.292515 1.065647,-0.174008 1.859143,0.09188 2.454747,0.435753 0.595604,0.343872 1.222619,0.898116 1.604747,1.907997 0.382128,1.00988 0.635407,2.118786 0.568269,3.569301 -0.13428,2.901032 -1.281736,6.37896 -3.270646,9.823853 -1.98891,3.444894 -4.427028,6.177362 -6.872255,7.744168 -1.222615,0.783401 -2.309721,1.118728 -3.375368,1.292736 C 18.4891,36.560912 17.695604,36.295023 17.1,35.951151 16.504396,35.607279 15.877381,35.053035 15.495253,34.043154 15.113125,33.033273 14.859846,31.924369 14.926984,30.473853 15.061264,27.572821 16.208719,24.094894 18.19763,20.65 Z"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3032);fill-opacity:1;stroke:none;stroke-width:0.64683139;marker:none;enable-background:accumulate" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:url(#radialGradient3034);fill-opacity:1;stroke:none;stroke-width:0.64683139;marker:none;enable-background:accumulate"
+         d="m 30.928203,20.028904 c 2.015155,3.465128 3.270326,6.933782 3.409235,9.91317 0.06945,1.489694 -0.104087,2.837018 -0.542367,3.986928 -0.43828,1.149911 -1.097078,2.280843 -2.295071,2.967506 -1.197994,0.686664 -2.513937,0.687611 -3.736177,0.489474 -1.22224,-0.198137 -2.484321,-0.722593 -3.749097,-1.527154 -2.529553,-1.609124 -4.927775,-4.422606 -6.942929,-7.887734 -2.015154,-3.465127 -3.270325,-6.933781 -3.409235,-9.913169 -0.06945,-1.489695 0.104087,-2.837019 0.542367,-3.986929 0.43828,-1.14991 1.097077,-2.280842 2.295071,-2.967506 1.197993,-0.686664 2.513937,-0.68761 3.736177,-0.489474 1.22224,0.198137 2.484321,0.722593 3.749098,1.527155 2.529552,1.609124 4.927774,4.422606 6.942928,7.887733 z m -1.125833,0.645303 c -1.98891,-3.419999 -4.427156,-6.132942 -6.872383,-7.688426 -1.222614,-0.777739 -2.309594,-1.110425 -3.37524,-1.283175 -1.065647,-0.17275 -1.859143,0.09122 -2.454747,0.432605 -0.595604,0.341387 -1.222619,0.891625 -1.604747,1.894209 -0.382128,1.002582 -0.635407,2.103475 -0.568269,3.543508 0.13428,2.880068 1.281736,6.332864 3.270646,9.752863 1.98891,3.42 4.427028,6.132723 6.872255,7.688206 1.222615,0.77774 2.309721,1.110644 3.375368,1.283395 1.065647,0.17275 1.859143,-0.09122 2.454747,-0.432604 0.595604,-0.341388 1.222619,-0.891626 1.604747,-1.89421 0.382128,-1.002583 0.635407,-2.103474 0.568269,-3.543508 -0.13428,-2.880068 -1.281735,-6.332863 -3.270646,-9.752863 z"
+         id="path3913"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssssssssssssssssssssssssss" />
+    </g>
+    <g
+       transform="translate(-0.79999924,0)"
+       id="g4295">
+      <circle
+         style="opacity:1;fill:url(#radialGradient4235);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle4191"
+         cx="23"
+         cy="22.5"
+         r="2.5" />
+      <circle
+         r="2.5"
+         cy="22"
+         cx="24.75"
+         id="circle4189"
+         style="opacity:1;fill:url(#radialGradient4259);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         r="2.5"
+         cy="22.75"
+         cx="27"
+         id="circle4193"
+         style="opacity:1;fill:url(#radialGradient4219);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:url(#radialGradient4251);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="path4187"
+         cx="22.799999"
+         cy="25"
+         r="2.5" />
+      <circle
+         r="2.5"
+         cy="25.25"
+         cx="26.75"
+         id="circle4211"
+         style="opacity:1;fill:url(#radialGradient4243);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <circle
+         style="opacity:1;fill:url(#radialGradient4227);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="circle4209"
+         cx="24.75"
+         cy="26"
+         r="2.5" />
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/kbounce.svg
+++ b/Numix-Circle/48x48/apps/kbounce.svg
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview59"
      showgrid="false"
-     inkscape:zoom="1"
-     inkscape:cx="2.765704"
-     inkscape:cy="24"
+     inkscape:zoom="8"
+     inkscape:cx="27.802426"
+     inkscape:cy="19"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -77,7 +77,8 @@
        y1="20"
        x2="37"
        y2="37"
-       gradientUnits="userSpaceOnUse" />
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-1.9999998,0)" />
     <linearGradient
        id="linearGradient3942">
       <stop
@@ -98,7 +99,7 @@
        y1="18"
        x2="20"
        y2="40"
-       gradientTransform="matrix(0.70692389,-0.70723967,0.70692389,0.70723967,-6.865178,21.415982)" />
+       gradientTransform="matrix(0.70692389,-0.70723967,0.70692389,0.70723967,-6.8570834,21.415982)" />
     <linearGradient
        id="linearGradient3820-1">
       <stop
@@ -168,21 +169,15 @@
      transform="matrix(-1,0,0,1,49.008001,0.00240892)"
      id="g4015">
     <path
-       sodipodi:nodetypes="csccscc"
-       inkscape:connector-curvature="0"
-       id="path3817-5"
-       d="m 27.40625,17.031126 c 1.156164,2.883792 0.584968,6.288989 -1.75,8.625 -2.34254,2.343586 -5.76791,2.921793 -8.65625,1.75 0.634029,0.414381 1.214891,0.807022 2.0625,1.34375 2.632133,0.653307 5.536372,-0.03545 7.59375,-2.09375 2.049722,-2.050638 2.734288,-4.937023 2.09375,-7.5625 -0.735234,-1.161796 -0.859702,-1.318665 -1.34375,-2.0625 z"
-       style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none" />
-    <path
        inkscape:connector-curvature="0"
        id="path3938"
-       d="m 21,13 c -2.046849,0 -4.094557,0.781359 -5.65625,2.34375 -3.123386,3.124781 -3.123386,8.187719 0,11.3125 0,0 18.400212,12.744358 21.25,9.9375 2.849787,-2.806857 -9.9375,-21.25 -9.9375,-21.25 C 25.094557,13.781359 23.046849,13 21,13 Z"
+       d="m 19,13 c -2.046849,0 -4.094557,0.781359 -5.65625,2.34375 -3.123386,3.124781 -3.123386,8.187719 0,11.3125 0,0 18.400212,12.744358 21.25,9.9375 2.849787,-2.806857 -9.9375,-21.25 -9.9375,-21.25 C 23.094557,13.781359 21.046849,13 19,13 Z"
        style="fill:url(#linearGradient3948);fill-opacity:1;fill-rule:nonzero;stroke:none" />
     <path
        sodipodi:nodetypes="zccz"
        inkscape:connector-curvature="0"
        id="path3817"
-       d="M 35.585602,35.596137 C 32.735814,38.402995 14.342539,25.65 14.342539,25.65 L 25.65,14.343586 c 0,0 12.785389,18.445694 9.935602,21.252551 z"
+       d="M 35.593697,35.596137 C 32.743909,38.402995 14.350634,25.65 14.350634,25.65 L 25.658095,14.343586 c 0,0 12.785389,18.445694 9.935602,21.252551 z"
        style="fill:url(#linearGradient3902);fill-opacity:1;fill-rule:nonzero;stroke:none" />
     <circle
        transform="matrix(0.80791299,-0.80827388,0.80791299,0.80827388,-13.934415,21.618051)"

--- a/Numix-Circle/48x48/apps/kbounce.svg
+++ b/Numix-Circle/48x48/apps/kbounce.svg
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kbounce.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="2.765704"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3029" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3942"
+       id="linearGradient3948"
+       x1="20"
+       y1="20"
+       x2="37"
+       y2="37"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient3942">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.11764706;"
+         offset="0"
+         id="stop3944" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.03921569;"
+         offset="1"
+         id="stop3946" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3820-1"
+       id="linearGradient3902"
+       gradientUnits="userSpaceOnUse"
+       x1="20"
+       y1="18"
+       x2="20"
+       y2="40"
+       gradientTransform="matrix(0.70692389,-0.70723967,0.70692389,0.70723967,-6.865178,21.415982)" />
+    <linearGradient
+       id="linearGradient3820-1">
+      <stop
+         style="stop-color:#939393;stop-opacity:1"
+         offset="0"
+         id="stop3822-9" />
+      <stop
+         style="stop-color:#9b9b9b;stop-opacity:0.23529412"
+         offset="1"
+         id="stop3824-0" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3809-6"
+       id="radialGradient3910"
+       gradientUnits="userSpaceOnUse"
+       cx="21.780729"
+       cy="17.702995"
+       fx="21.780729"
+       fy="17.702995"
+       r="7" />
+    <linearGradient
+       id="linearGradient3809-6">
+      <stop
+         style="stop-color:#97cef9;stop-opacity:1"
+         offset="0"
+         id="stop3811-9" />
+      <stop
+         style="stop-color:#6f8ee9;stop-opacity:1"
+         offset="1"
+         id="stop3813-5" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     transform="matrix(-1,0,0,1,49.008001,0.00240892)"
+     id="g4015">
+    <path
+       sodipodi:nodetypes="csccscc"
+       inkscape:connector-curvature="0"
+       id="path3817-5"
+       d="m 27.40625,17.031126 c 1.156164,2.883792 0.584968,6.288989 -1.75,8.625 -2.34254,2.343586 -5.76791,2.921793 -8.65625,1.75 0.634029,0.414381 1.214891,0.807022 2.0625,1.34375 2.632133,0.653307 5.536372,-0.03545 7.59375,-2.09375 2.049722,-2.050638 2.734288,-4.937023 2.09375,-7.5625 -0.735234,-1.161796 -0.859702,-1.318665 -1.34375,-2.0625 z"
+       style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3938"
+       d="m 21,13 c -2.046849,0 -4.094557,0.781359 -5.65625,2.34375 -3.123386,3.124781 -3.123386,8.187719 0,11.3125 0,0 18.400212,12.744358 21.25,9.9375 2.849787,-2.806857 -9.9375,-21.25 -9.9375,-21.25 C 25.094557,13.781359 23.046849,13 21,13 Z"
+       style="fill:url(#linearGradient3948);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <path
+       sodipodi:nodetypes="zccz"
+       inkscape:connector-curvature="0"
+       id="path3817"
+       d="M 35.585602,35.596137 C 32.735814,38.402995 14.342539,25.65 14.342539,25.65 L 25.65,14.343586 c 0,0 12.785389,18.445694 9.935602,21.252551 z"
+       style="fill:url(#linearGradient3902);fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    <circle
+       transform="matrix(0.80791299,-0.80827388,0.80791299,0.80827388,-13.934415,21.618051)"
+       id="path3039"
+       style="fill:url(#radialGradient3910);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       cx="22"
+       cy="20"
+       r="7" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/kigo.svg
+++ b/Numix-Circle/48x48/apps/kigo.svg
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kigo.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="9.301141"
+     inkscape:cy="23.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#82b339;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#8dc13f;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-489686994">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-1">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-4" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-497882810">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-9">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-3" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g4201">
+    <g
+       id="g35">
+      <g
+         id="g37"
+         clip-path="url(#clipPath-489686994)">
+        <g
+           id="g39"
+           transform="translate(1,1)">
+          <g
+             style="opacity:0.1"
+             id="g41">
+            <!-- color: #91c8ff -->
+            <g
+               id="g43">
+              <path
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 inkscape:connector-curvature="0"
+                 id="path45"
+                 d="M 23,30.5 C 23,33.539 20.539,36 17.5,36 14.461,36 12,33.539 12,30.5 12,27.461 14.461,25 17.5,25 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+              <path
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 inkscape:connector-curvature="0"
+                 id="path47"
+                 d="M 36,30.5 C 36,33.539 33.539,36 30.5,36 27.461,36 25,33.539 25,30.5 25,27.461 27.461,25 30.5,25 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+              <path
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 inkscape:connector-curvature="0"
+                 id="path49"
+                 d="M 23,17.5 C 23,20.539 20.539,23 17.5,23 14.461,23 12,20.539 12,17.5 12,14.461 14.461,12 17.5,12 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+              <path
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+                 inkscape:connector-curvature="0"
+                 id="path51"
+                 d="M 36,17.5 C 36,20.539 33.539,23 30.5,23 27.461,23 25,20.539 25,17.5 25,14.461 27.461,12 30.5,12 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+    <g
+       id="g53">
+      <g
+         id="g55"
+         clip-path="url(#clipPath-497882810)">
+        <!-- color: #91c8ff -->
+        <g
+           id="g57">
+          <path
+             style="fill:#2d2d2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path59"
+             d="M 23,30.5 C 23,33.539 20.539,36 17.5,36 14.461,36 12,33.539 12,30.5 12,27.461 14.461,25 17.5,25 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+          <path
+             style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path61-3"
+             d="M 36,30.5 C 36,33.539 33.539,36 30.5,36 27.461,36 25,33.539 25,30.5 25,27.461 27.461,25 30.5,25 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+          <path
+             style="fill:#f9f9f9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path63"
+             d="M 23,17.5 C 23,20.539 20.539,23 17.5,23 14.461,23 12,20.539 12,17.5 12,14.461 14.461,12 17.5,12 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+          <path
+             style="fill:#2d2d2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path65"
+             d="M 36,17.5 C 36,20.539 33.539,23 30.5,23 27.461,23 25,20.539 25,17.5 25,14.461 27.461,12 30.5,12 c 3.039,0 5.5,2.461 5.5,5.5 m 0,0" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/kmahjongg.svg
+++ b/Numix-Circle/48x48/apps/kmahjongg.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kmahjongg3.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="23.272475"
+     inkscape:cy="25.739134"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="false"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#b33c29;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#c3412d;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:20px;line-height:125%;font-family:Montserrat;-inkscape-font-specification:Montserrat;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     x="17"
+     y="18"
+     id="text4202"
+     sodipodi:linespacing="125%"><tspan
+       sodipodi:role="line"
+       id="tspan4204"
+       x="17"
+       y="18"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Changa;-inkscape-font-specification:Changa" /></text>
+  <g
+     id="g4199">
+    <path
+       style="fill:#000000;fill-opacity:0.09803922"
+       d="M 24.33,37.800713 C 23.906076,37.327903 24,35.999999 24,31.690383 l 0,-4.690384 c -2,0.251744 -3,0.525482 -4.25301,0.98043 -0.517676,0.64035 -0.74699,0.73789 -1.210869,0.28314 -0.378855,-0.39914 -0.60977,-1.231686 -1.610342,-4.609086 -0.280581,-0.94709 -0.735932,-2.21859 -1.011897,-2.82556 -0.602744,-1.32574 -0.559756,-1.62682 0.211982,-1.48438 0.292391,0.0539 0.812369,0.212951 1.155467,0.414091 C 17.712593,19.999999 18,19.999999 18.599103,19.949999 20.347335,19.576886 22,19.248669 24,18.799999 l 0,-2.214716 c 0,-2.585284 -0.261857,-2.43666 -0.638195,-3.1669 -0.73082,-1.41802 -0.278135,-1.80468 1.188865,-1.01548 1.170754,0.62983 1.759618,1.31541 1.639242,1.90851 C 26.140082,14.556823 26,15.502703 26,16.585223 l 0,1.864776 c 2,-0.5 4,-0.842738 5.788979,-1.05 0.734614,0 2.71102,1.513724 2.71102,2.071774 0,0.15465 -0.163702,0.49781 -0.363785,0.76258 -0.337263,0.44632 -1.073226,2.06454 -1.792365,3.66339 -0.166664,0.37056 -0.303022,0.93558 -0.303022,1.25562 0,0.45475 -0.0534,0.846636 -0.244676,0.846636 -1.325596,0 -5.378826,0.679227 -5.796151,0.76 0,7.221 0,10.24 -0.873009,11.091404 -0.227586,0.20789 -0.568969,0.20363 -0.796991,-0.05069 z M 24,24.999999 l 0,-4.6 c 0,0 -3.675796,0.65142 -5.032208,1 -0.746176,0.19177 -0.624485,0.6 0.266483,3.87289 0.147572,0.542091 0.35349,0.711669 0.683234,0.62711 C 21,25.622406 22,25.357089 24,24.999999 Z m 6.3,-1 c 0.32431,-0.154 0.285049,-0.142496 0.75,-2.266146 0.374911,-1.7125 0.534221,-2.318934 0.35,-2.433854 -0.113471,-0.224164 -3.4,0.231655 -5.4,0.7 l 0,4.7 c 2,-0.356908 3.337853,-0.51843 4.3,-0.7 z"
+       id="path4197"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccssccccccsccccsccsscccccccsccccccc" />
+    <path
+       sodipodi:nodetypes="cscccssccccccsccccsccsscccccccsccccccc"
+       inkscape:connector-curvature="0"
+       id="path4140"
+       d="M 23.33,36.800714 C 22.906076,36.327904 23,35 23,30.690384 L 23,26 c -2,0.251744 -3,0.525482 -4.25301,0.98043 -0.517676,0.64035 -0.74699,0.73789 -1.210869,0.28314 -0.378855,-0.39914 -0.60977,-1.231686 -1.610342,-4.609086 -0.280581,-0.94709 -0.735932,-2.21859 -1.011897,-2.82556 -0.602744,-1.32574 -0.559756,-1.62682 0.211982,-1.48438 0.292391,0.0539 0.812369,0.212951 1.155467,0.414091 C 16.712593,19 17,19 17.599103,18.95 19.347335,18.576887 21,18.24867 23,17.8 l 0,-2.214716 C 23,13 22.738143,13.148624 22.361805,12.418384 c -0.73082,-1.41802 -0.278135,-1.80468 1.188865,-1.01548 1.170754,0.62983 1.759618,1.31541 1.639242,1.90851 C 25.140082,13.556824 25,14.502704 25,15.585224 L 25,17.45 c 2,-0.5 4,-0.842738 5.788979,-1.05 0.734614,0 2.71102,1.513724 2.71102,2.071774 0,0.15465 -0.163702,0.49781 -0.363785,0.76258 -0.337263,0.44632 -1.073226,2.06454 -1.792365,3.66339 -0.166664,0.37056 -0.303022,0.93558 -0.303022,1.25562 C 31.040827,24.608114 30.987425,25 30.796151,25 29.470555,25 25.417325,25.679227 25,25.76 25,32.981 25,36 24.126991,36.851404 23.899405,37.059294 23.558022,37.055034 23.33,36.800714 Z M 23,24 23,19.4 c 0,0 -3.675796,0.65142 -5.032208,1 -0.746176,0.19177 -0.624485,0.6 0.266483,3.87289 0.147572,0.542091 0.35349,0.711669 0.683234,0.62711 C 20,24.622407 21,24.35709 23,24 Z m 6.3,-1 c 0.32431,-0.154 0.285049,-0.142496 0.75,-2.266146 C 30.424911,19.021354 30.584221,18.41492 30.4,18.3 30.286529,18.075836 27,18.531655 25,19 l 0,4.7 c 2,-0.356908 3.337853,-0.51843 4.3,-0.7 z"
+       style="fill:#e6e6e6" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/kmines.svg
+++ b/Numix-Circle/48x48/apps/kmines.svg
@@ -1,0 +1,1 @@
+gnome-mines.svg


### PR DESCRIPTION
Icons for several KDE games. Fixes #1578

Bovo
![bovo](https://cloud.githubusercontent.com/assets/7050624/6204082/85e17aea-b53d-11e4-9a48-7a83304983a2.png)


KAtomic
![katomic](https://cloud.githubusercontent.com/assets/7050624/6204077/7d9dd63a-b53d-11e4-984e-5970dbaf0ba4.png)


KBounce
![kbounce1](https://cloud.githubusercontent.com/assets/7050624/6204149/90703912-b540-11e4-913e-52f2f4cf11cd.png)



Kigo
![kigo1](https://cloud.githubusercontent.com/assets/7050624/6204075/6ce56c9a-b53d-11e4-96a6-eea11d346236.png)


KMahjongg
![kmahjongg-icon](https://cloud.githubusercontent.com/assets/7050624/6204073/66dd3878-b53d-11e4-9322-c42054cdb0b7.png)


KMines
symlink to *gnome-mines.svg*