### PR TITLE
Icon for Cutegram. Fixes #1581

### DIFF
--- a/Numix-Circle/48x48/apps/cutegram.svg
+++ b/Numix-Circle/48x48/apps/cutegram.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="cutegram.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="9.301141"
+     inkscape:cy="23.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#d22724;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#db322f;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       y2="160"
+       x2="160"
+       y1="120"
+       x1="135"
+       gradientTransform="matrix(0.05622958,0,0,0.05622958,0.07160145,-0.0527796)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3102"
+       xlink:href="#4-7"
+       inkscape:collect="always" />
+    <linearGradient
+       id="4-7">
+      <stop
+         stop-color="#eff7fc"
+         id="stop67" />
+      <stop
+         offset="1"
+         stop-color="#ffffff"
+         id="stop69" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g4209">
+    <g
+       style="opacity:0.1;fill:#000000;fill-opacity:1"
+       id="g4218"
+       transform="scale(3.543307,3.543307)">
+      <path
+         style="fill:#000000;fill-opacity:1"
+         inkscape:connector-curvature="0"
+         d="m 5.5821004,9.7873968 c -0.2186006,0 -0.1814527,-0.08254 -0.2568453,-0.290678 L 4.6819505,7.3809617 8.6632908,4.8935174 9.1278995,5.0150305 8.7419171,6.0729093 Z"
+         id="path4220" />
+      <path
+         style="fill:#000000;fill-opacity:1"
+         inkscape:connector-curvature="0"
+         d="m 5.5821004,9.7873968 c 0.1686887,0 0.2434679,-0.07689 0.3373774,-0.168689 C 6.0644574,9.4769908 7.9437428,7.650673 7.9437428,7.650673 L 6.7926147,7.3720493 5.7242527,8.0468043 5.5821004,9.7311668 Z"
+         id="path4222" />
+      <path
+         style="fill:#000000;fill-opacity:1"
+         inkscape:connector-curvature="0"
+         d="m 5.6969419,8.0671532 2.7192722,2.0090178 c 0.3103035,0.171212 0.5342597,0.08257 0.6115675,-0.2880942 L 10.134669,4.5720625 C 10.247995,4.1177148 9.9614767,3.9116351 9.6646205,4.0464176 L 3.1648194,6.5533393 C 2.7211634,6.731289 2.7237485,6.9788071 3.0839509,7.089093 L 4.7518626,7.6096833 8.6133308,5.1735215 c 0.182289,-0.1105407 0.3495945,-0.051112 0.2122796,0.07076 z"
+         id="path4224" />
+    </g>
+    <g
+       id="g82"
+       transform="matrix(3.543307,0,0,3.543307,-0.99999987,-1.0000008)">
+      <path
+         id="path84"
+         d="m 5.5821004,9.7873968 c -0.2186006,0 -0.1814527,-0.08254 -0.2568453,-0.290678 L 4.6819505,7.3809617 8.6632908,4.8935174 9.1278995,5.0150305 8.7419171,6.0729093 Z"
+         inkscape:connector-curvature="0"
+         style="fill:#c8daea" />
+      <path
+         id="path86"
+         d="m 5.5821004,9.7873968 c 0.1686887,0 0.2434679,-0.07689 0.3373774,-0.168689 C 6.0644574,9.4769908 7.9437428,7.650673 7.9437428,7.650673 L 6.7926147,7.3720493 5.7242527,8.0468043 5.5821004,9.7311668 Z"
+         inkscape:connector-curvature="0"
+         style="fill:#a7c2d1" />
+      <path
+         id="path88"
+         d="m 5.6969419,8.0671532 2.7192722,2.0090178 c 0.3103035,0.171212 0.5342597,0.08257 0.6115675,-0.2880942 L 10.134669,4.5720625 C 10.247995,4.1177148 9.9614767,3.9116351 9.6646205,4.0464176 L 3.1648194,6.5533393 C 2.7211634,6.731289 2.7237485,6.9788071 3.0839509,7.089093 L 4.7518626,7.6096833 8.6133308,5.1735215 c 0.182289,-0.1105407 0.3495945,-0.051112 0.2122796,0.07076 z"
+         inkscape:connector-curvature="0"
+         style="fill:url(#linearGradient3102)" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Cutegram. Fixes #1581
![cutegram](https://cloud.githubusercontent.com/assets/7050624/6275955/95c81e48-b883-11e4-9756-fbe771540ed0.png)
