### PR TITLE
Icon for GPA (symlink). Fixes #1593

### DIFF
--- a/Numix-Circle/48x48/apps/gpa.svg
+++ b/Numix-Circle/48x48/apps/gpa.svg
@@ -1,0 +1,1 @@
+stock_keyring.svg


### PR DESCRIPTION
Icon for GPA (symlink). Fixes #1593

Symbolic link to *stock_keyring.svg*