### PR TITLE
Icon for KPhotoAlbum (symlink). Fixes #1595

### DIFF
--- a/Numix-Circle/48x48/apps/kphotoalbum.svg
+++ b/Numix-Circle/48x48/apps/kphotoalbum.svg
@@ -1,0 +1,1 @@
+fotowall.svg


### PR DESCRIPTION
Icon for KPhotoAlbum (symlink). Fixes #1595

Symbolic link to *fotowall.svg*