### PR TITLE
Icon for Ezame (symlink). Fixes #1073

### DIFF
--- a/Numix-Circle/48x48/apps/ezame.svg
+++ b/Numix-Circle/48x48/apps/ezame.svg
@@ -1,0 +1,1 @@
+menu-editor.svg


### PR DESCRIPTION
Icon for Ezame. Fixes #1073
Symlink to existing *menu-editor.svg*