### PR TITLE
Icon for Rapid Photo Downloader. Fixes #966

### DIFF
--- a/Numix-Circle/48x48/apps/rapid-photo-downloader.svg
+++ b/Numix-Circle/48x48/apps/rapid-photo-downloader.svg
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="rapid-photo-downloader1.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="-121.91878"
+     inkscape:cy="23.89989"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3765-5-8-9"
+       id="linearGradient5371"
+       gradientUnits="userSpaceOnUse"
+       x1="-25.499998"
+       y1="15"
+       x2="-25.499998"
+       y2="11" />
+    <linearGradient
+       id="linearGradient3765-5-8-9">
+      <stop
+         style="stop-color:#46baa7;stop-opacity:1;"
+         offset="0"
+         id="stop3767-6-1-8" />
+      <stop
+         style="stop-color:#51c1af;stop-opacity:1;"
+         offset="1"
+         id="stop3769-8-1-4" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:url(#linearGradient5371);fill-opacity:1.0;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(4.3274075,0,0,3.2455556,117.12222,-35.418889)" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol">
+    <g
+       id="Layer_1_1_"
+       transform="matrix(0.02315104,0,0,0.02315104,0.85426011,0.84828994)" />
+    <g
+       id="Layer_1_1_-8"
+       transform="matrix(0.02315104,0,0,0.02315104,17.950949,0.34726084)" />
+    <g
+       id="g3012"
+       transform="translate(-17.317044,0.17132354)" />
+    <g
+       id="g3012-2"
+       transform="translate(-1.401132,0.05067354)" />
+    <g
+       id="g3012-8"
+       transform="translate(-17.317044,0.17132354)" />
+    <g
+       id="g3012-2-6"
+       transform="translate(-1.401132,0.05067354)" />
+    <rect
+       id="rect2348"
+       ry="0"
+       style="opacity:0.6;fill:#000000"
+       height="0"
+       width="2.2577779"
+       y="-93.977951"
+       x="-23.655239" />
+    <rect
+       style="fill:#b3b3b3;fill-opacity:1"
+       id="rect4830"
+       width="0.28222224"
+       height="0.84666669"
+       x="9.3133345"
+       y="5.0800004"
+       rx="0.056444447" />
+    <path
+       style="fill:#000000;fill-opacity:0.09803922"
+       d="m 5.0800002,3.3866663 -0.8466667,0.8466667 0,1.6933334 0.169223,0 0,0.5644445 -0.169223,0 0,3.9511111 c -5.93e-5,0.282223 0.2822222,0.282223 0.2822222,0.282223 l 5.0800001,0 c 0,0 0.2822274,0 0.2822223,-0.282223 l 0,-3.1044445 -0.169223,0 0,-1.1288889 0.1129989,0 c 0.03127,0 0.056224,-0.024954 0.056224,-0.056224 l 0,-0.7342186 c 0,-0.03127 -0.024954,-0.056224 -0.056224,-0.056224 l 0.056224,0 0,-1.6933333 C 9.8777832,3.3866663 9.5955558,3.3866663 9.5955558,3.3866663 l -4.5155556,0 z"
+       id="rect5358"
+       inkscape:connector-curvature="0" />
+    <g
+       id="g3366">
+      <rect
+         rx="0.056444447"
+         y="5.0799999"
+         x="9.3133335"
+         height="0.84666669"
+         width="0.28222224"
+         id="rect4830-5"
+         style="fill:#073642;fill-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path3041"
+         d="m 9.4262222,5.0800003 0.169269,0 0,-1.6933334 c 5e-6,-0.2822222 -0.282217,-0.2822222 -0.282217,-0.2822222 l -4.5155555,0 -0.8466075,0.8466667 0,1.6933334 0.1693334,0 0,0.5644444 -0.1693334,0 0,3.9511108 c -5.92e-5,0.282223 0.282163,0.282223 0.282163,0.282223 l 5.08,0 c 0,0 0.282222,0 0.282217,-0.282223 l 0,-3.1044441 -0.169269,0 z"
+         style="fill:#b04340;fill-opacity:1;stroke:none" />
+      <g
+         id="g4836"
+         transform="matrix(0.28222223,0,0,0.28222223,-64.989506,-109.33084)">
+        <path
+           transform="matrix(0.99999449,0.00331825,-0.00390057,0.99999239,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 246.84161,400.57671 1.99997,-0.007 0.0156,4 -1.99999,0.007 z"
+           id="rect3549"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           transform="matrix(0.99999274,0.00381118,-0.00339608,0.99999423,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 249.63273,398.44368 1.50002,-5e-5 0.0136,3.99431 -1.49998,0.006 z"
+           id="rect3563"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           transform="matrix(0.99999274,0.00381118,-0.00339609,0.99999423,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 251.63272,398.43605 1.49999,-0.006 0.0136,4.00001 -1.49999,0.006 z"
+           id="rect3574"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           id="rect3580"
+           sodipodi:nodetypes="cccccc"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 252.29216,399.39292 -0.0143,3.99981 1.49991,2.1e-4 1.2e-4,-4.00021 -1.50012,-1.3e-4 z" />
+        <path
+           transform="matrix(0.99999274,0.00381118,-0.00339609,0.99999423,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 257.63269,398.41314 1.50004,-0.006 0.0135,3.99996 -1.49994,0.006 z"
+           id="rect3598"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           transform="matrix(0.99999274,0.00381118,-0.00339608,0.99999423,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 259.63267,398.40554 1.50003,-0.006 0.0136,3.99999 -1.49996,0.006 z"
+           id="rect3606"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           transform="matrix(0.99999295,0.00375465,-0.00344723,0.99999406,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 261.65303,398.41265 1.4,-0.005 0.0138,3.99994 -1.39999,0.005 z"
+           id="rect3612"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           transform="matrix(0.9999965,0.00264585,-0.00489181,0.99998804,0,0)"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 263.82906,398.69945 1.39998,-0.004 0.0196,4.00001 -1.39999,0.004 z"
+           id="rect3614"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccc" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4021"
+           sodipodi:nodetypes="cccccc"
+           style="fill:#c3ad69;fill-opacity:1"
+           d="m 254.2922,399.39271 -0.0143,4.00002 1.49987,0 1.6e-4,-4 -1.50016,-3.4e-4 z" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/rapid-photo-downloader.svg
+++ b/Numix-Circle/48x48/apps/rapid-photo-downloader.svg
@@ -14,7 +14,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="rapid-photo-downloader1.svg">
+   sodipodi:docname="rapid-photo-downloader4.svg">
   <metadata
      id="metadata331">
     <rdf:RDF>
@@ -41,8 +41,8 @@
      id="namedview329"
      showgrid="false"
      inkscape:zoom="1"
-     inkscape:cx="-121.91878"
-     inkscape:cy="23.89989"
+     inkscape:cx="28.081222"
+     inkscape:cy="22.257754"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -162,90 +162,52 @@
        rx="0.056444447" />
     <path
        style="fill:#000000;fill-opacity:0.09803922"
-       d="m 5.0800002,3.3866663 -0.8466667,0.8466667 0,1.6933334 0.169223,0 0,0.5644445 -0.169223,0 0,3.9511111 c -5.93e-5,0.282223 0.2822222,0.282223 0.2822222,0.282223 l 5.0800001,0 c 0,0 0.2822274,0 0.2822223,-0.282223 l 0,-3.1044445 -0.169223,0 0,-1.1288889 0.1129989,0 c 0.03127,0 0.056224,-0.024954 0.056224,-0.056224 l 0,-0.7342186 c 0,-0.03127 -0.024954,-0.056224 -0.056224,-0.056224 l 0.056224,0 0,-1.6933333 C 9.8777832,3.3866663 9.5955558,3.3866663 9.5955558,3.3866663 l -4.5155556,0 z"
+       d="m 9.0311114,3.3866663 0.8466667,0.8466667 0,1.6933334 -0.169223,0 0,0.5644445 0.169223,0 0,3.9511111 c 5.93e-5,0.282223 -0.2822222,0.282223 -0.2822222,0.282223 l -5.0800001,0 c 0,0 -0.2822274,0 -0.2822223,-0.282223 l 0,-3.1044445 0.169223,0 0,-1.1288889 -0.1129989,0 c -0.03127,0 -0.056224,-0.024954 -0.056224,-0.056224 l 0,-0.7342186 c 0,-0.03127 0.024954,-0.056224 0.056224,-0.056224 l -0.056224,0 0,-1.6933333 C 4.2333284,3.3866663 4.5155558,3.3866663 4.5155558,3.3866663 l 4.5155556,0 z"
        id="rect5358"
        inkscape:connector-curvature="0" />
     <g
-       id="g3366">
-      <rect
-         rx="0.056444447"
-         y="5.0799999"
-         x="9.3133335"
-         height="0.84666669"
-         width="0.28222224"
-         id="rect4830-5"
-         style="fill:#073642;fill-opacity:1" />
-      <path
-         sodipodi:nodetypes="ccccccccccccccccc"
-         inkscape:connector-curvature="0"
-         id="path3041"
-         d="m 9.4262222,5.0800003 0.169269,0 0,-1.6933334 c 5e-6,-0.2822222 -0.282217,-0.2822222 -0.282217,-0.2822222 l -4.5155555,0 -0.8466075,0.8466667 0,1.6933334 0.1693334,0 0,0.5644444 -0.1693334,0 0,3.9511108 c -5.92e-5,0.282223 0.282163,0.282223 0.282163,0.282223 l 5.08,0 c 0,0 0.282222,0 0.282217,-0.282223 l 0,-3.1044441 -0.169269,0 z"
-         style="fill:#b04340;fill-opacity:1;stroke:none" />
+       id="g3361">
       <g
-         id="g4836"
-         transform="matrix(0.28222223,0,0,0.28222223,-64.989506,-109.33084)">
+         transform="matrix(-1,0,0,1,13.546667,0)"
+         id="g5382">
+        <rect
+           style="fill:#9e5452;fill-opacity:1"
+           id="rect4830-5"
+           width="0.28222224"
+           height="0.84666669"
+           x="9.3133335"
+           y="5.0799999"
+           rx="0.056444447" />
         <path
-           transform="matrix(0.99999449,0.00331825,-0.00390057,0.99999239,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 246.84161,400.57671 1.99997,-0.007 0.0156,4 -1.99999,0.007 z"
-           id="rect3549"
+           style="fill:#084150;fill-opacity:1;stroke:none"
+           d="m 9.4262222,5.0800003 0.169269,0 0,-1.6933334 c 5e-6,-0.2822222 -0.282217,-0.2822222 -0.282217,-0.2822222 l -4.5155555,0 -0.8466075,0.8466667 0,1.6933334 0.1693334,0 0,0.5644444 -0.1693334,0 0,3.9511108 c -5.92e-5,0.282223 0.282163,0.282223 0.282163,0.282223 l 5.08,0 c 0,0 0.282222,0 0.282217,-0.282223 l 0,-3.1044441 -0.169269,0 z"
+           id="path3041"
            inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           transform="matrix(0.99999274,0.00381118,-0.00339608,0.99999423,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 249.63273,398.44368 1.50002,-5e-5 0.0136,3.99431 -1.49998,0.006 z"
-           id="rect3563"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           transform="matrix(0.99999274,0.00381118,-0.00339609,0.99999423,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 251.63272,398.43605 1.49999,-0.006 0.0136,4.00001 -1.49999,0.006 z"
-           id="rect3574"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           id="rect3580"
-           sodipodi:nodetypes="cccccc"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 252.29216,399.39292 -0.0143,3.99981 1.49991,2.1e-4 1.2e-4,-4.00021 -1.50012,-1.3e-4 z" />
-        <path
-           transform="matrix(0.99999274,0.00381118,-0.00339609,0.99999423,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 257.63269,398.41314 1.50004,-0.006 0.0135,3.99996 -1.49994,0.006 z"
-           id="rect3598"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           transform="matrix(0.99999274,0.00381118,-0.00339608,0.99999423,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 259.63267,398.40554 1.50003,-0.006 0.0136,3.99999 -1.49996,0.006 z"
-           id="rect3606"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           transform="matrix(0.99999295,0.00375465,-0.00344723,0.99999406,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 261.65303,398.41265 1.4,-0.005 0.0138,3.99994 -1.39999,0.005 z"
-           id="rect3612"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           transform="matrix(0.9999965,0.00264585,-0.00489181,0.99998804,0,0)"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 263.82906,398.69945 1.39998,-0.004 0.0196,4.00001 -1.39999,0.004 z"
-           id="rect3614"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           id="path4021"
-           sodipodi:nodetypes="cccccc"
-           style="fill:#c3ad69;fill-opacity:1"
-           d="m 254.2922,399.39271 -0.0143,4.00002 1.49987,0 1.6e-4,-4 -1.50016,-3.4e-4 z" />
+           sodipodi:nodetypes="ccccccccccccccccc" />
+        <g
+           transform="matrix(0.28222223,0,0,0.28222223,-64.989506,-109.33084)"
+           id="g4836" />
       </g>
+      <rect
+         style="fill:#9e5452;fill-opacity:1;stroke:none"
+         id="rect3349"
+         width="3.9511113"
+         height="5.6444445"
+         x="4.7977781"
+         y="4.2333336"
+         ry="0.0062362892" />
+      <path
+         style="fill:#ececec;fill-opacity:1;stroke:none"
+         d="m 7.3377809,8.1844432 -0.5644462,0 0,0.2822223 0.2822222,0 c 0,0 0.2822223,0 0.2822223,0.2822222 l 0,0.5644445 c 0,0 0,0.2822222 -0.2822223,0.2822222 l -0.5644444,0 0,-0.2822222 0.5644444,0 0,-0.5644445 -0.2822222,0 c 0,8e-7 -0.2822222,0 -0.2822222,-0.2610378 l 0,-0.3494176 c 0,-0.2362113 0.2822222,-0.2362113 0.2822222,-0.2362113 l 0.5644428,0 z"
+         id="path3351"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccccc" />
+      <path
+         style="fill:#ececec;fill-opacity:1;stroke:none"
+         d="m 7.6200014,8.3255544 0.2822222,0 0,0.9877778 0.2822223,0 0,-1.128889 -0.5644036,0 -8.18e-5,-0.2822222 0.5644854,0 c 0.2315103,0 0.2822222,0.1446084 0.2822222,0.2822222 l 0,1.128889 c 0,0.2822222 -0.2822222,0.2822222 -0.2822222,0.2822222 l -0.5644445,0 z"
+         id="path3353"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccc" />
     </g>
   </g>
 </svg>


### PR DESCRIPTION
Icon for Rapid Photo Downloader. Fixes #966
Pushed:
![rapid-photo-downloader1](https://cloud.githubusercontent.com/assets/7050624/6364116/289fa142-bca2-11e4-880b-4c7b874663ee.png)
Alts:
![rapid-photo-downloader2](https://cloud.githubusercontent.com/assets/7050624/6364119/3118acd8-bca2-11e4-806e-8544486102bc.png)
![rapid-photo-downloader4](https://cloud.githubusercontent.com/assets/7050624/6364124/36d40942-bca2-11e4-8c52-ec9e070296c0.png)

