### PR TITLE
Icon for Kapow. Fixes #1611

### DIFF
--- a/Numix-Circle/48x48/apps/kapow.svg
+++ b/Numix-Circle/48x48/apps/kapow.svg
@@ -1,0 +1,1 @@
+gnome-schedule.svg


### PR DESCRIPTION
Icon for Kapow. Fixes #1611

Symlink to *gnome-schedule.svg*