### PR TITLE
Icon for KTimeTracker(symlink). Fixes #1618

### DIFF
--- a/Numix-Circle/48x48/apps/ktimetracker.svg
+++ b/Numix-Circle/48x48/apps/ktimetracker.svg
@@ -1,0 +1,1 @@
+indicator-remindor.svg


### PR DESCRIPTION
Icon for KTimeTracker(symlink). Fixes #1618

Symlink to *indicator-remindor.svg*