### PR TITLE
Icon for Flowblade. Fixes #1632

### DIFF
--- a/Numix-Circle/48x48/apps/flowblade.svg
+++ b/Numix-Circle/48x48/apps/flowblade.svg
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg27375"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="flowblade5b.svg">
+  <metadata
+     id="metadata27434">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview27432"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="21.194794"
+     inkscape:cy="23.785534"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg27375"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3360" />
+  </sodipodi:namedview>
+  <defs
+     id="defs27377">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4172">
+      <stop
+         style="stop-color:#96ae7c;stop-opacity:1"
+         offset="0"
+         id="stop4174" />
+      <stop
+         style="stop-color:#a0b688;stop-opacity:1"
+         offset="1"
+         id="stop4176" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4172"
+       id="linearGradient4178"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g27394">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path27396" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path27398" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27400" />
+  </g>
+  <g
+     id="g27402">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path27404"
+       style="fill:url(#linearGradient4178);fill-opacity:1" />
+  </g>
+  <g
+     id="g27406" />
+  <g
+     id="g27428">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path27430" />
+  </g>
+  <g
+     id="g4274">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:0.09803922"
+       d="m 13,12 c -0.554,0 -1,0.446 -1,1 l 0,24 c 0,0.554 0.446,1 1,1 l 24,0 c 0.554,0 1,-0.446 1,-1 l 0,-24 c 0,-0.554 -0.446,-1 -1,-1 l -24,0 z m 1,2 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m -18,18 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z"
+       id="path4264" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect4223"
+       d="m 12,11 c -0.554,0 -1,0.446 -1,1 l 0,24 c 0,0.554 0.446,1 1,1 l 24,0 c 0.554,0 1,-0.446 1,-1 l 0,-24 c 0,-0.554 -0.446,-1 -1,-1 l -24,0 z m 1,2 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m -18,18 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z"
+       style="fill:#464646;fill-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4164"
+       d="m 14,27 c 0,0 0,0 0,-6 1.631893,0 1.59746,3.999872 3.333,4 1.735753,1.28e-4 1.598247,-4.000128 3.334,-4 1.73554,1.28e-4 1.59746,4 3.333,4 1.73554,0 1.59746,-4 3.333,-4 1.73554,0 1.59746,3.999872 3.333,4 1.735753,1.28e-4 1.76445,-4 3.334,-4 0,6 0,6 0,6 z"
+       style="fill:#cccccc;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Flowblade. Fixes #1632 
Pushed:
![flowblade5b](https://cloud.githubusercontent.com/assets/7050624/6439793/bc7dd842-c0d6-11e4-9863-28ea6465f060.png)

Alt:
![flowblade6a](https://cloud.githubusercontent.com/assets/7050624/6439823/10d4ff74-c0d7-11e4-8eca-37403d3b579f.png)
![flowblade3](https://cloud.githubusercontent.com/assets/7050624/6439797/c846ed44-c0d6-11e4-8925-369083732e9c.png)
![flowblade1b](https://cloud.githubusercontent.com/assets/7050624/6439830/19706e84-c0d7-11e4-8858-0f7e1d902031.png)



