### PR TITLE
Icon for nomacs (symlink). Fixes #1635

### DIFF
--- a/Numix-Circle/48x48/apps/nomacs.svg
+++ b/Numix-Circle/48x48/apps/nomacs.svg
@@ -1,0 +1,1 @@
+kuickshow.svg


### PR DESCRIPTION
Icon for nomacs (symlink). Fixes #1635

Symlink to *kuickshow.svg*