### PR TITLE
Icon for MultiWriter. Fixes #1640

### DIFF
--- a/Numix-Circle/48x48/apps/gnome-multi-writer.svg
+++ b/Numix-Circle/48x48/apps/gnome-multi-writer.svg
@@ -5,16 +5,13 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   width="100%"
-   height="100%"
-   sodipodi:docname="gnome-multi-writer1.svg">
+   sodipodi:docname="gnome-multi-writer2b.svg">
   <metadata
      id="metadata65">
     <rdf:RDF>
@@ -23,7 +20,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,52 +37,36 @@
      inkscape:window-height="713"
      id="namedview63"
      showgrid="false"
+     showguides="false"
      inkscape:zoom="1"
-     inkscape:cx="12.442411"
-     inkscape:cy="26.692911"
+     inkscape:cx="153.18514"
+     inkscape:cy="22.938447"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid3045" />
+       id="grid4193" />
   </sodipodi:namedview>
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4229">
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
       <stop
-         style="stop-color:#ad7fa8;stop-opacity:1"
-         offset="0"
-         id="stop4231" />
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
       <stop
-         style="stop-color:#b58bb0;stop-opacity:1"
          offset="1"
-         id="stop4233" />
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
     </linearGradient>
-    <clipPath
-       id="clipPath-617278102">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g17">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           fill="#1890d0"
-           id="path19" />
-      </g>
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4229"
-       id="linearGradient4235"
-       x1="-27"
-       y1="13"
-       x2="-24"
-       y2="13"
-       gradientUnits="userSpaceOnUse" />
   </defs>
   <g
      id="g21">
@@ -103,31 +84,15 @@
        id="path27" />
   </g>
   <g
-     id="g33" />
-  <path
-     sodipodi:type="arc"
-     style="fill:url(#linearGradient4235);fill-opacity:1;stroke:none"
-     id="path3942"
-     sodipodi:cx="-25.5"
-     sodipodi:cy="13"
-     sodipodi:rx="1.5"
-     sodipodi:ry="2"
-     d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
-     transform="matrix(0,-15.333333,11.5,0,-125.5,-366.99999)" />
-  <g
-     id="g3857"
-     transform="translate(1,0)"
-     style="opacity:0.1;fill:#000000;fill-opacity:1">
-    <g
-       id="g3859"
-       clip-path="url(#clipPath-617278102)"
-       style="fill:#000000;fill-opacity:1">
-      <!-- color: #004c8c -->
-      <g
-         id="g3861"
-         style="fill:#000000;fill-opacity:1" />
-    </g>
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
   </g>
+  <g
+     id="g33" />
   <g
      id="g59">
     <path
@@ -136,90 +101,93 @@
        id="path61" />
   </g>
   <g
-     transform="translate(2,0)"
-     id="g3411"
-     style="fill:#000000;fill-opacity:0.09803922">
+     id="g4265"
+     transform="translate(1,1)">
     <g
-       id="g3413"
-       transform="translate(0,-1)"
-       style="fill:#000000;fill-opacity:0.09803922">
-      <g
-         clip-path="url(#clipPath-617278102)"
-         id="g3415"
-         style="fill:#000000;fill-opacity:0.09803922">
-        <!-- color: #004c8c -->
-        <g
-           id="g3417"
-           style="fill:#000000;fill-opacity:0.09803922">
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
-             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
-             transform="translate(0,1)"
-             id="path3419" />
-        </g>
-      </g>
-    </g>
-    <g
-       transform="translate(12,-1)"
-       id="g3421"
-       style="fill:#000000;fill-opacity:0.09803922">
-      <g
-         id="g3423"
-         clip-path="url(#clipPath-617278102)"
-         style="fill:#000000;fill-opacity:0.09803922">
-        <!-- color: #004c8c -->
-        <g
-           id="g3425"
-           style="fill:#000000;fill-opacity:0.09803922">
-          <path
-             id="path3427"
-             transform="translate(0,1)"
-             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
-             style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
-             inkscape:connector-curvature="0" />
-        </g>
-      </g>
-    </g>
+       id="g4267"
+       transform="translate(4,1)" />
   </g>
   <g
-     id="g3382"
-     transform="translate(1,-1)">
+     id="g4289">
     <g
-       transform="translate(0,-1)"
-       id="g49">
-      <g
-         id="g51"
-         clip-path="url(#clipPath-617278102)">
-        <!-- color: #004c8c -->
-        <g
-           id="g53">
-          <path
-             id="path55"
-             transform="translate(0,1)"
-             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
-             style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             inkscape:connector-curvature="0" />
-        </g>
-      </g>
+       id="g4139"
+       transform="matrix(-1,0,0,-1,41,45)">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4279"
+         transform="matrix(-1,0,0,-1,41,45)"
+         d="m 19,12 c -5,1.88e-4 -5,4 -5,6 l 0,12.998047 C 14,32.10662 14,33 15,33 l 0,5 8,0 0,-5 c 1,0 1,-0.89338 1,-2.001953 L 24,18 c 0,-2 0,-6.000188 -5,-6 z"
+         style="fill:#000000;fill-opacity:0.09803922;stroke:none" />
+      <rect
+         style="fill:#758c95;fill-opacity:1;stroke:none"
+         id="rect3763"
+         width="8"
+         height="6"
+         x="19"
+         y="-14"
+         transform="scale(1,-1)" />
+      <path
+         style="fill:#935799;fill-opacity:1;stroke:none"
+         d="m 23,33.999906 c 5,-1.88e-4 5,-3.999812 5,-5.999812 L 28,15.001035 C 28,13.892462 28,13 27,13 l -8,0 c -1,0 -1,0.892462 -1,2.001035 l 0,12.999059 c 0,2 0,6 5,5.999812 z"
+         id="rect2991"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="zcsssscz" />
+      <rect
+         style="opacity:0.65397925;fill:#083b48;fill-opacity:1;stroke:none"
+         id="rect3767"
+         width="2"
+         height="2"
+         x="20"
+         y="-10.999998"
+         transform="scale(1,-1)" />
+      <rect
+         style="opacity:0.65397925;fill:#083b48;fill-opacity:1;stroke:none"
+         id="rect3769"
+         width="2"
+         height="2"
+         x="24"
+         y="-10.999998"
+         transform="scale(1,-1)" />
     </g>
     <g
-       id="g3374"
-       transform="translate(12,-1)">
-      <g
-         clip-path="url(#clipPath-617278102)"
-         id="g3376">
-        <!-- color: #004c8c -->
-        <g
-           id="g3378">
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
-             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
-             transform="translate(0,1)"
-             id="path3380" />
-        </g>
-      </g>
+       transform="matrix(-1,0,0,-1,53,45)"
+       id="g3409">
+      <path
+         inkscape:connector-curvature="0"
+         id="rect4283"
+         transform="matrix(-1,0,0,-1,53,45)"
+         d="m 31,12 c -5,1.88e-4 -5,4 -5,6 l 0,12.998047 C 26,32.10662 26,33 27,33 l 0,5 8,0 0,-5 c 1,0 1,-0.89338 1,-2.001953 L 36,18 c 0,-2 0,-6.000188 -5,-6 z"
+         style="fill:#000000;fill-opacity:0.09803922;stroke:none" />
+      <rect
+         transform="scale(1,-1)"
+         y="-14"
+         x="19"
+         height="6"
+         width="8"
+         id="rect3411"
+         style="fill:#758c95;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="zcsssscz"
+         inkscape:connector-curvature="0"
+         id="path3413"
+         d="m 23,33.999906 c 5,-1.88e-4 5,-3.999812 5,-5.999812 L 28,15.001035 C 28,13.892462 28,13 27,13 l -8,0 c -1,0 -1,0.892462 -1,2.001035 l 0,12.999059 c 0,2 0,6 5,5.999812 z"
+         style="fill:#935799;fill-opacity:1;stroke:none" />
+      <rect
+         transform="scale(1,-1)"
+         y="-10.999998"
+         x="20"
+         height="2"
+         width="2"
+         id="rect3415"
+         style="opacity:0.65397925;fill:#083b48;fill-opacity:1;stroke:none" />
+      <rect
+         transform="scale(1,-1)"
+         y="-10.999998"
+         x="24"
+         height="2"
+         width="2"
+         id="rect3417"
+         style="opacity:0.65397925;fill:#083b48;fill-opacity:1;stroke:none" />
     </g>
   </g>
 </svg>

--- a/Numix-Circle/48x48/apps/gnome-multi-writer.svg
+++ b/Numix-Circle/48x48/apps/gnome-multi-writer.svg
@@ -1,0 +1,225 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="gnome-multi-writer1.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="12.442411"
+     inkscape:cy="26.692911"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3045" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4229">
+      <stop
+         style="stop-color:#ad7fa8;stop-opacity:1"
+         offset="0"
+         id="stop4231" />
+      <stop
+         style="stop-color:#b58bb0;stop-opacity:1"
+         offset="1"
+         id="stop4233" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-617278102">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4229"
+       id="linearGradient4235"
+       x1="-27"
+       y1="13"
+       x2="-24"
+       y2="13"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g33" />
+  <path
+     sodipodi:type="arc"
+     style="fill:url(#linearGradient4235);fill-opacity:1;stroke:none"
+     id="path3942"
+     sodipodi:cx="-25.5"
+     sodipodi:cy="13"
+     sodipodi:rx="1.5"
+     sodipodi:ry="2"
+     d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+     transform="matrix(0,-15.333333,11.5,0,-125.5,-366.99999)" />
+  <g
+     id="g3857"
+     transform="translate(1,0)"
+     style="opacity:0.1;fill:#000000;fill-opacity:1">
+    <g
+       id="g3859"
+       clip-path="url(#clipPath-617278102)"
+       style="fill:#000000;fill-opacity:1">
+      <!-- color: #004c8c -->
+      <g
+         id="g3861"
+         style="fill:#000000;fill-opacity:1" />
+    </g>
+  </g>
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="translate(2,0)"
+     id="g3411"
+     style="fill:#000000;fill-opacity:0.09803922">
+    <g
+       id="g3413"
+       transform="translate(0,-1)"
+       style="fill:#000000;fill-opacity:0.09803922">
+      <g
+         clip-path="url(#clipPath-617278102)"
+         id="g3415"
+         style="fill:#000000;fill-opacity:0.09803922">
+        <!-- color: #004c8c -->
+        <g
+           id="g3417"
+           style="fill:#000000;fill-opacity:0.09803922">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
+             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
+             transform="translate(0,1)"
+             id="path3419" />
+        </g>
+      </g>
+    </g>
+    <g
+       transform="translate(12,-1)"
+       id="g3421"
+       style="fill:#000000;fill-opacity:0.09803922">
+      <g
+         id="g3423"
+         clip-path="url(#clipPath-617278102)"
+         style="fill:#000000;fill-opacity:0.09803922">
+        <!-- color: #004c8c -->
+        <g
+           id="g3425"
+           style="fill:#000000;fill-opacity:0.09803922">
+          <path
+             id="path3427"
+             transform="translate(0,1)"
+             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
+             style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g3382"
+     transform="translate(1,-1)">
+    <g
+       transform="translate(0,-1)"
+       id="g49">
+      <g
+         id="g51"
+         clip-path="url(#clipPath-617278102)">
+        <!-- color: #004c8c -->
+        <g
+           id="g53">
+          <path
+             id="path55"
+             transform="translate(0,1)"
+             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
+             style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0" />
+        </g>
+      </g>
+    </g>
+    <g
+       id="g3374"
+       transform="translate(12,-1)">
+      <g
+         clip-path="url(#clipPath-617278102)"
+         id="g3376">
+        <!-- color: #004c8c -->
+        <g
+           id="g3378">
+          <path
+             inkscape:connector-curvature="0"
+             style="fill:#f0f0f0;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             d="m 13,13 c -0.999899,-4.61e-4 -1,0.660386 -1,1.486328 l 0,17.029297 C 12,32.340556 12.000101,33 13,33 l 0,4 8,0 0,-4 c 1.000908,0 1,-0.658433 1,-1.484375 L 22,14.486328 C 22,13.661397 22.000908,12.999539 21,13 l -8,0 z M 14.003906,34 16,34 l 0,2 -1.996094,0 0,-2 z M 18,34 l 2,0 0,2 -2,0 0,-2 z"
+             transform="translate(0,1)"
+             id="path3380" />
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for MultiWriter. Fixes #1640
Pushed:
![gnome-multi-writer-icon](https://cloud.githubusercontent.com/assets/7050624/6463319/87fe0d5e-c1b1-11e4-83d8-29d45ddfca5c.png)
Alt:
![gnome-multi-writer2c](https://cloud.githubusercontent.com/assets/7050624/6475049/a8330570-c206-11e4-9d56-0f262cd60ffb.png)



