### PR TITLE
Symlinks for Flightgear

### DIFF
--- a/Numix-Circle/48x48/apps/fgfs.svg
+++ b/Numix-Circle/48x48/apps/fgfs.svg
@@ -1,0 +1,1 @@
+flightgear.svg

--- a/Numix-Circle/48x48/apps/fgrun.svg
+++ b/Numix-Circle/48x48/apps/fgrun.svg
@@ -1,0 +1,1 @@
+flightgear.svg


### PR DESCRIPTION
Added symlinks *fgfs.svg* and *fgrun.svg* (in case it isn't hardcoded on some distros).

See #1630