### PR TITLE
Icon for KNetAttach. Fixes #1645

### DIFF
--- a/Numix-Circle/48x48/apps/knetattach.svg
+++ b/Numix-Circle/48x48/apps/knetattach.svg
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="knetattach1.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="37.258252"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#97b2d3"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#a5bcd9"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <path
+     id="path4195"
+     d="m 35.589844,13 -6.662109,6.654297 c -2.193925,-1.527741 -5.233148,-1.32356 -7.199219,0.628906 l 7.693359,8.261719 c 0.09195,-0.07663 0.175553,-0.157894 0.263672,-0.242188 1.973569,-1.959887 2.192861,-5.02045 0.65625,-7.230468 L 37,14.410156 35.589844,13 Z m -15.011719,8.455078 c -0.08812,0.07663 -0.175472,0.153987 -0.259765,0.238281 -1.97766,1.960548 -2.196479,5.022233 -0.658203,7.232422 L 13,35.585937 14.414063,37 l 6.65625,-6.664062 c 2.196251,1.528915 5.233847,1.330662 7.201172,-0.623047 l -7.69336,-8.257813 z"
+     style="fill:#000000;fill-opacity:0.09803922"
+     inkscape:connector-curvature="0" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#323232;fill-opacity:1"
+     d="m 34.589844,12 -6.662109,6.654297 c -2.193925,-1.527741 -5.233148,-1.32356 -7.199219,0.628906 l 7.693359,8.261719 c 0.09195,-0.07663 0.175553,-0.157894 0.263672,-0.242188 1.973569,-1.959887 2.192861,-5.02045 0.65625,-7.230468 L 36,13.410156 34.589844,12 Z m -15.011719,8.455078 c -0.08812,0.07663 -0.175472,0.153987 -0.259765,0.238281 -1.97766,1.960548 -2.196479,5.022233 -0.658203,7.232422 L 12,34.585937 13.414063,36 l 6.65625,-6.664062 c 2.196251,1.528915 5.233847,1.330662 7.201172,-0.623047 l -7.69336,-8.257813 z"
+     id="path6" />
+</svg>


### PR DESCRIPTION
Icon for KNetAttach. Fixes #1645
![knetattach](https://cloud.githubusercontent.com/assets/7050624/6474662/0ebb8690-c203-11e4-98f0-9460b24e209e.png)
Alt:
![knetattach3](https://cloud.githubusercontent.com/assets/7050624/6474663/1581e7ee-c203-11e4-83bc-37d58c19e468.png)
or simply a symlink to *remote-desktop.svg*