### PR TITLE
Icon for LabPlot (symlink). Fixes #1643

### DIFF
--- a/Numix-Circle/48x48/apps/LabPlot2.svg
+++ b/Numix-Circle/48x48/apps/LabPlot2.svg
@@ -1,0 +1,1 @@
+kmplot.svg


### PR DESCRIPTION
Icon for LabPlot. Fixes #1643

symlink to *kmplot.svg*