### PR TITLE
Icon for Kolf. Fixes #1651

### DIFF
--- a/Numix-Circle/48x48/apps/kolf.svg
+++ b/Numix-Circle/48x48/apps/kolf.svg
@@ -1,0 +1,164 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kolf3.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     showguides="false"
+     inkscape:zoom="1"
+     inkscape:cx="29.332375"
+     inkscape:cy="17.953689"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3389" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4277">
+      <stop
+         style="stop-color:#8ed97b;stop-opacity:1"
+         offset="0"
+         id="stop4279" />
+      <stop
+         style="stop-color:#9bdd8b;stop-opacity:1"
+         offset="1"
+         id="stop4281" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-824049301">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4277"
+       id="linearGradient4283"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient4283);fill-opacity:1" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g47">
+    <g
+       clip-path="url(#clipPath-824049301)"
+       id="g49">
+      <!-- color: #7dc06d -->
+      <g
+         id="g51" />
+    </g>
+  </g>
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     id="g4246"
+     transform="matrix(0.96114819,0,0,0.97122245,0.51664859,1.5730463)">
+    <path
+       style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none"
+       d="m 15.033014,11.765845 c -0.06056,0.0038 -0.121754,0.02011 -0.178194,0.05011 l -1.630003,0.866878 c -0.225758,0.120037 -0.303714,0.413994 -0.174443,0.657118 l 5.600911,10.532461 c 0.129272,0.243125 0.415739,0.340933 0.641498,0.220896 L 19.51787,23.97265 c 2.917141,5.632944 6.004643,11.388491 6.593168,11.683347 1.031615,0.516842 2.131278,1.272677 6.688832,0.469635 4.681802,-0.824934 4.577127,-1.435935 4.920024,-2.643325 1.066019,-4.138827 -1.651085,-5.070176 -4.083451,-3.400682 -1.369148,0.87325 -2.692195,1.855484 -4.0797,2.827096 -0.614874,0.211215 -1.223059,0.290275 -1.772559,0.144789 -2.814311,-3.208678 -4.959947,-6.334357 -7.005828,-9.750973 l 0.144431,-0.07611 c 0.225758,-0.120039 0.301837,-0.412138 0.172566,-0.655262 L 15.496318,12.038716 c -0.09695,-0.182342 -0.281616,-0.284246 -0.463304,-0.272871 z"
+       id="path4285"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sccccccssccccccccs" />
+    <path
+       sodipodi:nodetypes="ccsccccc"
+       style="fill:#858585;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path24438"
+       d="m 12.942994,12.062066 c 0,0 10.963819,21.982687 12.126874,22.565385 1.031635,0.516854 2.130943,1.271264 6.688588,0.468206 4.681895,-0.82495 4.578089,-1.436129 4.920992,-2.643543 1.216375,-4.722583 -2.492325,-5.271046 -5.083927,-2.542308 -1.344301,1.224545 -3.32136,2.519809 -4.851103,2.114792 C 21.264046,25.776267 18.31444,19.860106 13.713521,11.447033 Z"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       style="fill:#a6a6a6;fill-opacity:1;fill-rule:evenodd;stroke:none"
+       id="path24491"
+       d="m 31.602316,29.71847 -3.217625,2.25323 c -3.749067,2.680267 1.706674,2.687516 2.864566,2.524497 1.984772,-0.304574 4.048532,-0.619301 4.555097,-1.896545 1.152,-4.303631 -1.617231,-4.977231 -4.202038,-2.881182 z"
+       inkscape:connector-curvature="0" />
+    <rect
+       transform="matrix(0.46947156,0.88294759,-0.88294759,0.46947156,0,0)"
+       ry="0.46153846"
+       rx="0.49704143"
+       y="-7.5946584"
+       x="16.009655"
+       height="2.7692308"
+       width="12.923077"
+       id="rect4244"
+       style="fill:#595959;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Kolf. Fixes #1651
![kolf3](https://cloud.githubusercontent.com/assets/7050624/6507916/ad4356a0-c355-11e4-9c23-517b5b60bde1.png)
