### PR TITLE
Icon for Foobnix. Fixes #1652

### DIFF
--- a/Numix-Circle/48x48/apps/foobnix.svg
+++ b/Numix-Circle/48x48/apps/foobnix.svg
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="foobnix.svg">
+  <metadata
+     id="metadata76">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview74"
+     showgrid="false"
+     inkscape:zoom="8"
+     inkscape:cx="28.347455"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3404" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4228">
+      <stop
+         style="stop-color:#356193;stop-opacity:1"
+         offset="0"
+         id="stop4230" />
+      <stop
+         style="stop-color:#3a6ba2;stop-opacity:1"
+         offset="1"
+         id="stop4232" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-284830246">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-289812246">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4228"
+       id="linearGradient4234"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g32">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path34" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path36" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path38" />
+  </g>
+  <g
+     id="g40">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path42"
+       style="fill:url(#linearGradient4234);fill-opacity:1" />
+  </g>
+  <g
+     id="g44" />
+  <g
+     id="g46">
+    <g
+       clip-path="url(#clipPath-284830246)"
+       id="g48">
+      <g
+         transform="translate(1,1)"
+         id="g50">
+        <g
+           opacity="0.1"
+           id="g52">
+          <!-- color: #474747 -->
+          <g
+             id="g54" />
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g60">
+    <g
+       clip-path="url(#clipPath-289812246)"
+       id="g62">
+      <!-- color: #474747 -->
+      <g
+         id="g64">
+        <path
+           style="fill:#000000;fill-opacity:0.09803922"
+           id="path3407"
+           d="M 16.542969,13 C 14.585969,13 13,14.585969 13,16.542969 l 0,16.914062 C 13,35.414031 14.585969,37 16.542969,37 l 16.914062,0 C 35.414031,37 37,35.414031 37,33.457031 L 37,16.542969 C 37,14.585969 35.414031,13 33.457031,13 L 16.542969,13 Z M 20,17 32,25 20,33 20,17 Z"
+           inkscape:connector-curvature="0" />
+        <path
+           d="M 15.542969 12 C 13.585969 12 12 13.585969 12 15.542969 L 12 32.457031 C 12 34.414031 13.585969 36 15.542969 36 L 32.457031 36 C 34.414031 36 36 34.414031 36 32.457031 L 36 15.542969 C 36 13.585969 34.414031 12 32.457031 12 L 15.542969 12 z M 19 16 L 31 24 L 19 32 L 19 16 z "
+           id="path66"
+           style="fill:#e6e6e6;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g70">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path72" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Foobnix. Fixes #1652
![foobnix](https://cloud.githubusercontent.com/assets/7050624/6507925/bf07efa4-c355-11e4-8bf3-f4e5a46bb1c6.png)
