### PR TITLE
Icon for gtklick (symlink). Fixes #1661

### DIFF
--- a/Numix-Circle/48x48/apps/gtklick.svg
+++ b/Numix-Circle/48x48/apps/gtklick.svg
@@ -1,0 +1,1 @@
+gtick.svg


### PR DESCRIPTION
Icon for gtklick (symlink). Fixes #1661

Symlink to *gtick.svg*