### PR TITLE
Icon for KMetronome (symlink). Fixes #1667

### DIFF
--- a/Numix-Circle/48x48/apps/kmetronome.svg
+++ b/Numix-Circle/48x48/apps/kmetronome.svg
@@ -1,0 +1,1 @@
+gtick.svg


### PR DESCRIPTION
Icon for KMetronome (symlink). Fixes #1667

Symlink to *gtick.svg*