### PR TITLE
Added missing symlinks for PyCAD, JabRef and Audio Tag Tool

### DIFF
--- a/Numix-Circle/48x48/apps/JabRef-icon-48.svg
+++ b/Numix-Circle/48x48/apps/JabRef-icon-48.svg
@@ -1,0 +1,1 @@
+jabref.svg

--- a/Numix-Circle/48x48/apps/TagTool.svg
+++ b/Numix-Circle/48x48/apps/TagTool.svg
@@ -1,0 +1,1 @@
+audio-tag-tool.svg

--- a/Numix-Circle/48x48/apps/gtkpycad.svg
+++ b/Numix-Circle/48x48/apps/gtkpycad.svg
@@ -1,0 +1,1 @@
+pycad.svg


### PR DESCRIPTION
gtkpycad.svg --> pycad.svg
TagTool.svg --> audio-tag-tool.svg
JabRef-icon-48.svg --> jabref.svg