### PR TITLE
Icon for PCB Desinger (symlink). Fixes #1692

### DIFF
--- a/Numix-Circle/48x48/apps/pcb.svg
+++ b/Numix-Circle/48x48/apps/pcb.svg
@@ -1,0 +1,1 @@
+cpuinfo.svg


### PR DESCRIPTION
Symlink to *cpuinfo.svg*