### PR TITLE
Icon for JACK keyboard

### DIFF
--- a/Numix-Circle/48x48/apps/jack-keyboard.svg
+++ b/Numix-Circle/48x48/apps/jack-keyboard.svg
@@ -1,0 +1,355 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="jackkey.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       y2="89.285004"
+       x2="307.78"
+       y1="209.78"
+       x1="307.78"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5259"
+       xlink:href="#linearGradient2762"
+       inkscape:collect="always" />
+    <linearGradient
+       id="linearGradient2762">
+      <stop
+         id="stop2764"
+         stop-color="#dfe0e2"
+         offset="0" />
+      <stop
+         id="stop2766"
+         stop-color="#fafbff"
+         offset="1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3217"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.8099634,0,0,1.0409089,105.3777,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3522"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3524"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3526"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3528"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3530"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2762"
+       id="linearGradient3532"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.88129476,0,0,1.0409089,19.368923,-48.86517)"
+       x1="307.78"
+       y1="209.78"
+       x2="307.78"
+       y2="89.285004" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     transform="scale(3.543307,3.543307)"
+     id="g4593">
+    <path
+       id="path3071"
+       d="m 3.8044918,4.2333339 6.5021322,0 c 0.231475,0 0.41782,0.1775929 0.41782,0.3981903 l 0,4.8480629 c 0,0.220598 -0.186345,0.398191 -0.41782,0.398191 l -6.5021322,0 c -0.2314742,0 -0.417825,-0.177593 -0.417825,-0.398191 l 0,-4.8480629 c 0,-0.2205974 0.1863508,-0.3981903 0.417825,-0.3981903 z"
+       style="fill:#000000;fill-opacity:0.17254902"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <g
+       id="g4548">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#373737;fill-opacity:1"
+         d="m 3.5189585,3.9511116 c -0.2314742,0 -0.414514,0.1762777 -0.414514,0.396875 l 0,4.8506946 c 0,0.2205976 0.1830398,0.3968747 0.414514,0.3968747 l 6.5087505,0 c 0.231474,0 0.414514,-0.1762771 0.414514,-0.3968747 l 0,-4.8506946 c 0,-0.2205973 -0.18304,-0.396875 -0.414514,-0.396875 z"
+         id="rect2933-7"
+         sodipodi:nodetypes="sssssssss" />
+      <g
+         id="g4556"
+         transform="matrix(0.03514303,0,0,0.03332415,0.09971475,3.7740934)">
+        <g
+           id="g3210"
+           transform="translate(792.1,-39.21)" />
+        <g
+           id="g4413">
+          <g
+             id="g4083">
+            <g
+               id="g3526"
+               transform="translate(-1.391,0)" />
+            <g
+               id="g3531"
+               transform="translate(1.2034,-0.48392)" />
+            <g
+               id="g3538" />
+            <g
+               id="g3543"
+               transform="translate(0.32488,0.48393)" />
+            <g
+               id="g3548" />
+          </g>
+          <g
+             id="g3942"
+             transform="translate(-173.8,0)">
+            <g
+               id="g3958"
+               transform="translate(-1.391,0)" />
+            <g
+               id="g3966"
+               transform="translate(1.2034,-0.48392)" />
+            <g
+               id="g3974" />
+            <g
+               id="g3982"
+               transform="translate(0.32488,0.48393)" />
+            <g
+               id="g3990" />
+          </g>
+          <g
+             id="g4113"
+             transform="translate(-347.6,0)">
+            <g
+               id="g4129"
+               transform="translate(-1.391,0)" />
+            <g
+               id="g4137"
+               transform="translate(1.2034,-0.48392)" />
+            <g
+               id="g4145" />
+            <g
+               id="g4153"
+               transform="translate(0.32488,0.48393)" />
+            <g
+               id="g4161" />
+          </g>
+          <g
+             id="g4213"
+             transform="translate(-521.4,0)">
+            <g
+               id="g4229"
+               transform="translate(-1.391,0)" />
+            <g
+               id="g4237"
+               transform="translate(1.2034,-0.48392)" />
+            <g
+               id="g4245" />
+            <g
+               id="g4253"
+               transform="translate(0.32488,0.48393)" />
+            <g
+               id="g4261" />
+          </g>
+          <g
+             id="g4313"
+             transform="translate(-695.2,0)">
+            <g
+               id="g4329"
+               transform="translate(-1.391,0)" />
+            <g
+               id="g4337"
+               transform="translate(1.2034,-0.48392)" />
+            <g
+               id="g4345" />
+            <g
+               id="g4353"
+               transform="translate(0.32488,0.48393)" />
+            <g
+               id="g4361">
+              <g
+                 id="g4084">
+                <path
+                   style="fill:url(#linearGradient3522)"
+                   d="m 862.80563,47.656996 c 0,0 0.002,76.548604 0.002,114.532494 0,2.23258 1.5248,4.03351 3.41501,4.03351 l 13.66008,0 c 1.89021,0 3.41501,-1.80093 3.41501,-4.03351 l 0,-38.31149 -3.91331,0 c -0.98577,0 -1.79013,-0.70722 -1.79013,-1.87155 l 0.002,-74.349454 z"
+                   id="path3234"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="ccssscsccc" />
+                <path
+                   style="fill:url(#linearGradient3524)"
+                   d="m 907.99016,123.878 -3.97746,0 c -0.98981,0 -1.80517,-0.70411 -1.79254,-1.87155 l 3.4e-4,-74.349454 -9.22912,0 -0.003,74.349454 c -0.006,1.16431 -0.80544,1.87155 -1.79254,1.87155 l -3.69594,0 0,38.31149 c 0,2.23258 1.52686,4.03351 3.41962,4.03351 l 13.65087,0 c 1.89275,0 3.41961,-1.80093 3.41961,-4.03351 z"
+                   id="path3232"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="csccccscssssc" />
+                <path
+                   style="fill:url(#linearGradient3526)"
+                   d="m 942.40435,47.656996 -3.4e-4,74.349454 c -10e-6,1.16592 -0.80407,1.87155 -1.79252,1.87155 l -3.72675,0 1.6e-4,38.31149 c 10e-6,2.23258 1.52685,4.03351 3.41959,4.03351 l 13.65076,0 c 1.89275,0 3.41959,-1.80093 3.41959,-4.03351 0,-12.90449 0,-114.532494 0,-114.532494 z"
+                   id="path3230"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="csscsssccc" />
+                <path
+                   style="fill:url(#linearGradient3528)"
+                   d="m 917.62395,47.656996 -3.4e-4,74.349454 c -10e-6,1.16752 -0.80174,1.87155 -1.79033,1.87155 l -3.64288,0 0.004,38.31149 c 0.005,2.23257 1.51854,4.03351 3.40898,4.03351 l 13.66167,0 c 1.89042,0 3.4154,-1.80093 3.4154,-4.03351 l 3e-5,-38.31149 -3.88915,0 c -0.98723,0 -1.79031,-0.70564 -1.79033,-1.87155 l -8.7e-4,-74.349454 z"
+                   id="path3228"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="cssccssscsscc" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:url(#linearGradient3530)"
+                   d="m 792.41838,47.656995 c -1.77209,0 -3.68768,1.768443 -3.68768,4.000995 l 0,110.33637 c 0,2.23248 1.91559,4.22864 3.68768,4.22864 l 13.60078,0 c 1.77211,0 3.20164,-1.99616 3.20164,-4.22864 l 0,-38.11636 -3.28414,0 c -0.93054,0 -1.67829,-0.73178 -1.67829,-1.90406 l 0,-74.316945 z"
+                   id="path3226"
+                   sodipodi:nodetypes="sssssscsscs" />
+                <path
+                   style="fill:url(#linearGradient3532)"
+                   d="m 833.91314,123.878 -3.48253,0 c -0.98981,0 -1.76496,-0.70404 -1.76496,-1.87155 l 0,-74.349454 -9.8636,0 0,74.316944 c 0,1.17228 -0.83062,1.7978 -1.82011,1.90406 l -3.5589,0 0,38.31149 c 0,2.23258 1.52686,4.03351 3.41962,4.03351 l 13.65087,0 c 1.89276,0 3.41961,-1.80093 3.41961,-4.03351 z"
+                   id="path3224"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="cssccsccssssc" />
+                <path
+                   style="fill:url(#linearGradient5259)"
+                   d="m 843.41525,47.656996 0,74.349454 c 0,1.16751 -0.80273,1.87155 -1.79253,1.87155 l -3.41954,0 -0.0878,38.31149 c -0.005,2.23257 1.52686,4.03351 3.41962,4.03351 l 13.65085,0 c 1.89276,0 3.41962,-1.80093 3.41962,-4.03351 0.006,-21.37349 1.1e-4,-114.532494 1.1e-4,-114.532494 z"
+                   id="path4148"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="cssccssccc" />
+                <path
+                   style="fill:url(#linearGradient3217)"
+                   d="m 960.98864,47.656996 c 0,0 0,78.577294 0,114.532494 0,2.23258 1.40139,4.03351 3.1386,4.03351 l 14.41486,0 c 1.73721,0 2.92476,-1.80093 2.92476,-4.03351 l 0,-110.560531 c 0,-2.574587 -1.99711,-3.971963 -3.76637,-3.971963 z"
+                   id="rect4215"
+                   inkscape:connector-curvature="0"
+                   sodipodi:nodetypes="ccsssssc" />
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for JACK keyboard. Fixes #1700
![jack-keyboard](https://cloud.githubusercontent.com/assets/7050624/6615702/9adb953a-c8a6-11e4-9d3b-f5339753c3e0.png)

