### PR TITLE
Icon for Connectagram. Fixes #1742

### DIFF
--- a/Numix-Circle/48x48/apps/connectagram.svg
+++ b/Numix-Circle/48x48/apps/connectagram.svg
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="connectagram.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="22.74159"
+     inkscape:cy="22.964466"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3393" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4222">
+      <stop
+         style="stop-color:#1b991b;stop-opacity:1"
+         offset="0"
+         id="stop4224" />
+      <stop
+         style="stop-color:#1eaa1e;stop-opacity:1"
+         offset="1"
+         id="stop4226" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4222"
+       id="linearGradient4228"
+       x1="11"
+       y1="36"
+       x2="11"
+       y2="12"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <rect
+     rx="3"
+     ry="3"
+     y="13"
+     x="13"
+     height="24"
+     width="24"
+     id="rect4230"
+     style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <g
+     id="g4269">
+    <rect
+       rx="3"
+       ry="3"
+       y="12"
+       x="12"
+       height="24"
+       width="24"
+       id="rect3395"
+       style="fill:url(#linearGradient4228);fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
+    <path
+       style="fill:#000000;fill-opacity:0.09803922"
+       d="m 26.621822,17.997609 c -0.806281,-0.0193 -1.587473,0.03938 -2.239537,0.183593 -2.441429,0.539967 -4.324334,2.142216 -5.070609,4.316407 -0.391807,1.141482 -0.419364,3.687407 -0.05341,4.849609 1.108923,3.522015 4.656142,5.229047 9.312274,4.478516 0.841988,-0.154328 1.640106,-0.451695 2.429462,-0.75 l 0,-2.865235 -0.733983,0.394532 c -2.289003,1.118564 -5.556473,1.102068 -6.841267,-0.957032 -1.157872,-1.932652 -0.751619,-5.026359 0.823009,-6.263672 1.37219,-1.078239 3.958689,-1.069623 6.012323,0.02148 L 31,21.798385 31,19 30.384721,18.712447 c -1.006252,-0.433338 -2.419094,-0.682672 -3.762899,-0.714838 z"
+       id="path4254"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssccccccsccccs" />
+    <path
+       sodipodi:nodetypes="sssccccccsccccs"
+       inkscape:connector-curvature="0"
+       id="path3338-3"
+       d="m 25.621822,16.997609 c -0.806281,-0.0193 -1.587473,0.03938 -2.239537,0.183593 -2.441429,0.539967 -4.324334,2.142216 -5.070609,4.316407 -0.391807,1.141482 -0.419364,3.687407 -0.05341,4.849609 1.108923,3.522015 4.656142,5.229047 9.312274,4.478516 0.841988,-0.154328 1.640106,-0.451695 2.429462,-0.75 l 0,-2.865235 -0.733983,0.394532 c -2.289003,1.118564 -5.556473,1.102068 -6.841267,-0.957032 -1.157872,-1.932652 -0.751619,-5.026359 0.823009,-6.263672 1.37219,-1.078239 3.958689,-1.069623 6.012323,0.02148 L 30,20.798385 30,18 29.384721,17.712447 c -1.006252,-0.433338 -2.419094,-0.682672 -3.762899,-0.714838 z"
+       style="fill:#ececec;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Connectagram. Fixes #1742
![connectagramicon](https://cloud.githubusercontent.com/assets/7050624/6737943/2e8e8918-ce6f-11e4-9cb8-a20dc3877d86.png)
