### PR TITLE
Icon for KMag. Fixes #1744

### DIFF
--- a/Numix-Circle/48x48/apps/kmag.svg
+++ b/Numix-Circle/48x48/apps/kmag.svg
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kmag0b.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="20.79277"
+     inkscape:cy="22.472656"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3040" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3952">
+      <stop
+         style="stop-color:#c9c9df;stop-opacity:1;"
+         offset="0"
+         id="stop3954" />
+      <stop
+         style="stop-color:#d5d5e7;stop-opacity:1;"
+         offset="1"
+         id="stop3956" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3952"
+       id="linearGradient3958"
+       x1="25"
+       y1="48"
+       x2="25"
+       y2="0.1351461"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       id="path31"
+       style="fill:url(#linearGradient3958);fill-opacity:1.0"
+       fill-opacity="1"
+       fill="url(#linearGradient3764)" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       id="path57"
+       opacity="0.1" />
+  </g>
+  <g
+     id="g3503"
+     transform="matrix(0.70710678,-0.70710678,0.70710678,0.70710678,3.7883407,31.853332)">
+    <path
+       inkscape:connector-curvature="0"
+       id="path4346"
+       d="M 34.536656,10.15287 A 8.9158496,8.9158496 0 0 0 25.620807,1.237021 8.9158496,8.9158496 0 0 0 16.770742,9.1622204 l -6.7952387,0 0,-0.4953249 -7.0293588,0 0,2.9719505 7.0293588,0 0,-0.495325 6.7894347,0 a 8.9158496,8.9158496 0 0 0 8.855869,7.9252 8.9158496,8.9158496 0 0 0 8.915849,-8.915851 z m -1.683331,0 a 7.2317448,7.2317448 0 0 1 -7.232518,7.232519 7.2317448,7.2317448 0 0 1 -7.232519,-7.232519 7.2317448,7.2317448 0 0 1 7.232519,-7.2325179 7.2317448,7.2317448 0 0 1 7.232518,7.2325179 z"
+       style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none" />
+    <g
+       id="g4349">
+      <circle
+         transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,19.844946,-25.202469)"
+         style="fill:#000000;fill-opacity:0.12941176"
+         id="path3403"
+         cx="28"
+         cy="20"
+         r="8" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path67"
+         d="M 34.536656,8.7386569 A 8.9158496,8.9158496 0 0 0 25.620807,-0.17719257 8.9158496,8.9158496 0 0 0 16.770742,7.7480069 l -6.7952392,0 0,-0.4953249 -7.0293584,0 0,2.97195 7.0293584,0 0,-0.495325 6.7894352,0 a 8.9158496,8.9158496 0 0 0 8.855869,7.9252 8.9158496,8.9158496 0 0 0 8.915849,-8.9158501 z m -1.683331,0 a 7.2317448,7.2317448 0 0 1 -7.232518,7.2325181 7.2317448,7.2317448 0 0 1 -7.232519,-7.2325181 7.2317448,7.2317448 0 0 1 7.232519,-7.2325183 7.2317448,7.2317448 0 0 1 7.232518,7.2325183 z"
+         style="fill:#323232;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for KMag. Fixes #1744
![kmag](https://cloud.githubusercontent.com/assets/7050624/6737955/50de091c-ce6f-11e4-9c47-8b4c97b1201c.png)
