### PR TITLE
Icon for gEDA Schematic Editor. Fixes #1752

### DIFF
--- a/Numix-Circle/48x48/apps/geda-gschem.svg
+++ b/Numix-Circle/48x48/apps/geda-gschem.svg
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="geda1.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="35.198494"
+     inkscape:cy="20.918882"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3818" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       id="path31"
+       fill-opacity="1"
+       fill="url(#linearGradient3764)" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="matrix(1.0001111,0,0,0.99429473,0.99866718,-8.8636752)"
+     id="g3797">
+    <g
+       id="g3799"
+       transform="matrix(0.92933103,0,0,0.92934034,1.6960418,3.4484849)" />
+  </g>
+  <g
+     id="g5284">
+    <g
+       id="g5273">
+      <g
+         id="g3028"
+         transform="translate(0,2.0000005)">
+        <g
+           transform="matrix(1.0001111,0,0,0.99429473,-0.00127825,-9.8636753)"
+           id="g3904">
+          <g
+             id="g3899"
+             transform="matrix(0.92933103,0,0,0.92934034,1.6960418,3.4484849)" />
+        </g>
+        <g
+           transform="matrix(0.99980004,0,0,0.74925073,-1.9996012e-4,25.743756)"
+           id="g3913">
+          <path
+             d="m 34.444087,13.684667 c 0,0 0.563113,-0.324 0.563113,-1.996 0,-1.613 -0.633127,-2.0000004 -0.633127,-2.0000004 l -15.366272,1e-7 -4.004601,1.9960003 4.004601,2.004"
+             id="path3808"
+             inkscape:connector-curvature="0"
+             style="fill:#000000;fill-opacity:0.11764706;fill-rule:nonzero;stroke:none"
+             sodipodi:nodetypes="cscccc" />
+          <path
+             sodipodi:nodetypes="cscccc"
+             style="fill:#ee9d3a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path85"
+             d="m 33.443887,12.35 c 0,0 0.563113,-0.324 0.563113,-1.996 0,-1.6130001 -0.633127,-2.0000001 -0.633127,-2.0000001 L 18.007601,8.354 14.003,10.35 l 4.004601,2.004" />
+          <path
+             sodipodi:nodetypes="ccc"
+             style="fill:#e2b75a;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path87"
+             d="m 18.0038,8.354 -4.0008,2 4.0008,2" />
+          <path
+             sodipodi:nodetypes="ccc"
+             style="fill:#2d2d2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+             inkscape:connector-curvature="0"
+             id="path89"
+             d="m 16.0034,9.354 -2.0004,0.994 2.0004,1.006" />
+        </g>
+      </g>
+      <path
+         id="path5271"
+         d="M 25,12 A 10,10 0 0 0 15,22 10,10 0 0 0 25,32 10,10 0 0 0 30,30.650391 L 30,32 l 2,0 0,-2.871094 A 10,10 0 0 0 35,22 10,10 0 0 0 32,14.861328 L 32,12 l -2,0 0,1.355469 A 10,10 0 0 0 25,12 Z m 0,1 a 9,9 0 0 1 4.908203,1.464844 L 23,18.443359 23,16 l -2,0 0,5 -4.939453,0 A 9,9 0 0 1 25,13 Z m 6.326172,2.609375 A 9,9 0 0 1 34,22 9,9 0 0 1 31.314453,28.410156 L 23,23.595703 23,20.404297 31.326172,15.609375 Z M 16.066406,23 21,23 l 0,5 2,0 0,-2.4375 6.892578,3.990234 A 9,9 0 0 1 25,31 9,9 0 0 1 16.066406,23 Z"
+         style="fill:#000000;fill-opacity:0.09803922"
+         inkscape:connector-curvature="0" />
+    </g>
+    <path
+       id="path4160"
+       d="M 24 11 A 10 10 0 0 0 14 21 A 10 10 0 0 0 24 31 A 10 10 0 0 0 29 29.650391 L 29 31 L 31 31 L 31 28.128906 A 10 10 0 0 0 34 21 A 10 10 0 0 0 31 13.861328 L 31 11 L 29 11 L 29 12.355469 A 10 10 0 0 0 24 11 z M 24 12 A 9 9 0 0 1 28.908203 13.464844 L 22 17.443359 L 22 15 L 20 15 L 20 20 L 15.060547 20 A 9 9 0 0 1 24 12 z M 30.326172 14.609375 A 9 9 0 0 1 33 21 A 9 9 0 0 1 30.314453 27.410156 L 22 22.595703 L 22 19.404297 L 30.326172 14.609375 z M 15.066406 22 L 20 22 L 20 27 L 22 27 L 22 24.5625 L 28.892578 28.552734 A 9 9 0 0 1 24 30 A 9 9 0 0 1 15.066406 22 z "
+       style="fill:#323232;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for gEDA Schematic Editor. Fixes #1752
Pushed:
![geda-gschem](https://cloud.githubusercontent.com/assets/7050624/6757295/5403a04a-cf30-11e4-95d5-7a41b734ef3f.png)
Alt:
![geda-gschem2](https://cloud.githubusercontent.com/assets/7050624/6757299/5a180a98-cf30-11e4-921d-28c46029ade5.png)
