### PR TITLE
Icon for KBreakout. Fixes #1758

### DIFF
--- a/Numix-Circle/48x48/apps/kbreakout.svg
+++ b/Numix-Circle/48x48/apps/kbreakout.svg
@@ -1,0 +1,235 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kbreakout0.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="13.53125"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#4e5b62"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#56656d"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4266"
+       id="linearGradient4272"
+       x1="23"
+       y1="23"
+       x2="37.999199"
+       y2="23.00016"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4266">
+      <stop
+         style="stop-color:#000000;stop-opacity:0.09803922"
+         offset="0"
+         id="stop4268" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.01960784"
+         offset="1"
+         id="stop4270" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4207"
+       id="linearGradient4197"
+       x1="13.166667"
+       y1="27.166666"
+       x2="42.333332"
+       y2="27.166666"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4207">
+      <stop
+         style="stop-color:#f9f4a5;stop-opacity:0.73160172"
+         offset="0"
+         id="stop4209" />
+      <stop
+         style="stop-color:#f9f4a5;stop-opacity:0.24242425"
+         offset="1"
+         id="stop4211" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4153"
+       id="radialGradient4159"
+       cx="19"
+       cy="19"
+       fx="19"
+       fy="19"
+       r="7"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-12.045517,6.9544827)" />
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4153">
+      <stop
+         style="stop-color:#ab951d;stop-opacity:1"
+         offset="0"
+         id="stop4155" />
+      <stop
+         style="stop-color:#9a861a;stop-opacity:1"
+         offset="1"
+         id="stop4157" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4207"
+       id="linearGradient3409"
+       gradientUnits="userSpaceOnUse"
+       x1="13.166667"
+       y1="27.166666"
+       x2="42.333332"
+       y2="27.166666" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     id="g4249">
+    <g
+       id="g4281">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4260"
+         d="M 17.859375,13.001953 A 6,6 0 0 0 15,13.804688 6,6 0 0 0 12.804688,22 6,6 0 0 0 13.09375,22.445312 C 14.245873,24.299068 18.070714,29.741446 21,33 l 8,0 C 32.774285,28.040631 38.766405,19.471724 37.917969,18.152344 37.262437,17.42219 31.705648,22.522195 27.089844,26.986328 25.897768,23.329746 24.541942,19.32021 23.738281,17.265625 A 6,6 0 0 0 23.195312,16 6,6 0 0 0 17.859375,13.001953 Z"
+         style="fill:url(#linearGradient4272);fill-opacity:1;stroke:none;stroke-opacity:0.19806764" />
+      <rect
+         rx="0.5"
+         ry="0.5"
+         y="33"
+         x="16"
+         height="4"
+         width="18"
+         id="rect4256"
+         style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4274">
+      <path
+         transform="matrix(0.85714286,0,0,0.85714286,0.71428568,1.7142856)"
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path4169"
+         d="m 25.062178,15.5 c 0.966498,1.674024 5.481782,15.512036 6.771155,19.833333 -3.5,0 -4.666666,0 -9.333333,0 C 18.861871,31.286259 13.904321,24.174024 12.937822,22.5 Z"
+         style="fill:url(#linearGradient3409);fill-opacity:1;stroke:none;stroke-opacity:0.19806764" />
+      <circle
+         r="7"
+         cy="25.954483"
+         cx="6.9544826"
+         id="path4153"
+         style="fill:url(#radialGradient4159);fill-opacity:1;stroke:none;stroke-opacity:0.19806764"
+         transform="matrix(0.74230749,-0.42857143,0.42857143,0.74230749,0.71428568,1.7142856)" />
+      <path
+         transform="matrix(0.85714286,0,0,0.85714286,0.71428568,1.7142856)"
+         style="fill:url(#linearGradient4197);fill-opacity:1;stroke:none;stroke-opacity:0.19806764"
+         d="M 22.5,35.333339 C 24.822138,33.021495 41.002344,16.634544 42.238179,18.011061 43.228021,19.550338 36.236666,29.547408 31.833333,35.333339 Z"
+         id="circle4166"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="fill:#cccccc;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="rect3364"
+         width="18"
+         height="4"
+         x="15"
+         y="32"
+         ry="0.5"
+         rx="0.5" />
+      <rect
+         ry="0.5"
+         rx="0.5"
+         y="33"
+         x="17"
+         height="2"
+         width="14"
+         id="rect4253"
+         style="fill:#a6a6a6;fill-opacity:1" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for KBreakout. Fixes #1758
Pushed:
![kbreakout0](https://cloud.githubusercontent.com/assets/7050624/6764796/106ff6b0-cfc3-11e4-9a01-f85488001849.png)

Alt:
![kbreakout1a](https://cloud.githubusercontent.com/assets/7050624/6764800/189aa0ba-cfc3-11e4-86fc-29aa8084f320.png)
![kbreakout1c](https://cloud.githubusercontent.com/assets/7050624/6764801/1d011756-cfc3-11e4-907e-039640cdac44.png)


