### PR TITLE
Icon for gImageReader. Fixes #1760

### DIFF
--- a/Numix-Circle/48x48/apps/gimagereader.svg
+++ b/Numix-Circle/48x48/apps/gimagereader.svg
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="gimagereader.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="22.326195"
+     inkscape:cy="33.194245"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847"
+       empspacing="5"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#24bbd2;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#2fc4db;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-442087651-1">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-6-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-4-0" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <g
+     id="g4149">
+    <g
+       id="g4080">
+      <g
+         id="g6075">
+        <g
+           transform="translate(-39,-5.9999999)"
+           id="g3606">
+          <g
+             id="g61-6"
+             transform="translate(39,6.9999999)">
+            <g
+               transform="translate(1,-2)"
+               id="g3858">
+              <path
+                 sodipodi:nodetypes="ccccccccccccccccccc"
+                 inkscape:connector-curvature="0"
+                 id="path5098"
+                 d="m 11,13 0,23.84375 C 23.282855,31.63663 15.528737,13.185727 28,13 z m 17,0 c 2.305128,0 4.616902,0.902441 6.375,2.65625 C 36.129098,17.409555 37,19.69709 37,22 l 0,-9 z m 9,9 c 0,2.30291 -0.870902,4.621194 -2.625,6.375 -12.873922,2.440017 -9.468361,-1.686844 -16.28125,5.6875 L 13.15625,39 37,39 z M 13.15625,39 11,36.84375 11,39 z"
+                 style="fill:#000000;fill-opacity:0.11952192;fill-rule:evenodd;stroke:none" />
+            </g>
+          </g>
+        </g>
+        <g
+           id="g5601">
+          <g
+             id="g5145">
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:#f5efef;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               id="path67-3"
+               d="m 37,11 -26,0 0,26 26,0"
+               sodipodi:nodetypes="cccc" />
+          </g>
+          <g
+             id="g5126">
+            <g
+               id="g3257">
+              <g
+                 transform="translate(0,-0.004)"
+                 id="g35">
+                <g
+                   clip-path="url(#clipPath-442087651-1)"
+                   id="g37">
+                  <g
+                     transform="translate(1,1)"
+                     id="g39">
+                    <g
+                       style="opacity:0.1"
+                       id="g41">
+                      <!-- color: #cccdb6 -->
+                      <g
+                         id="g43" />
+                    </g>
+                  </g>
+                </g>
+              </g>
+              <g
+                 id="g3251" />
+            </g>
+            <g
+               id="text5091"
+               style="font-size:19.6648159px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+               transform="scale(0.96219942,1.0392856)" />
+          </g>
+        </g>
+      </g>
+      <path
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,13 24,0 0,1 -24,0 z"
+         id="rect3285" />
+      <path
+         id="path4060"
+         d="m 12,15 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,17 24,0 0,1 -24,0 z"
+         id="path4062" />
+      <path
+         id="path4064"
+         d="m 12,19 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,21 24,0 0,1 -24,0 z"
+         id="path4066" />
+      <path
+         id="path4068"
+         d="m 12,23 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,25 24,0 0,1 -24,0 z"
+         id="path4070" />
+      <path
+         id="path4072"
+         d="m 12,27 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,29 24,0 0,1 -24,0 z"
+         id="path4074" />
+      <path
+         id="path4076"
+         d="m 12,31 24,0 0,1 -24,0 z"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#bfbfbf;fill-opacity:0.85258969;fill-rule:nonzero;stroke:none"
+         d="m 12,33 24,0 0,1 -24,0 z"
+         id="path4078" />
+    </g>
+    <path
+       inkscape:connector-curvature="0"
+       id="path5108"
+       d="m 29,12 c -2.309128,0 -4.620902,0.902442 -6.375,2.65625 -3.255111,3.250858 -3.466079,8.378689 -0.6875,11.90625 L 17.25,31.21875 16.9375,30.90625 12,35.84375 14.15625,38 19.09375,33.0625 18.75,32.75 23.40625,28.09375 c 3.529423,2.789485 8.709198,2.537473 11.96875,-0.71875 3.508195,-3.507613 3.508195,-9.21214 0,-12.71875 C 33.616902,12.902441 31.305128,12 29,12 z m 0,1.46875 c 1.922107,0 3.839419,0.746913 5.3125,2.21875 2.941164,2.940673 2.941164,7.684327 0,10.625 -2.945163,2.940672 -7.711087,2.940672 -10.65625,0 -2.941164,-2.940673 -2.941164,-7.684327 0,-10.625 C 25.129332,14.21466 27.074893,13.46875 29,13.46875 z"
+       style="fill:#000000;fill-opacity:0.11952192;fill-rule:nonzero;stroke:none" />
+    <path
+       style="fill:#f5efef;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 36.602,19.898 c 0,4.69679 -3.805,8.5 -8.5,8.5 -4.699,0 -8.504,-3.80321 -8.5,-8.5 -0.004,-4.692792 3.801,-8.5 8.5,-8.5 4.695,0 8.5,3.807208 8.5,8.5 m 0,0"
+       id="path63" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#d24c37;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 22.622,26.866 -1.504,-1.504 -4.934,4.934 1.504,1.504"
+       id="path69-5" />
+    <path
+       style="fill:#b19b9b;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 27.986499,11.000001 c -2.309128,0 -4.598255,0.8869 -6.352353,2.640708 -3.512195,3.507606 -3.512195,9.221973 0,12.728584 3.508195,3.507609 9.223513,3.507609 12.734708,0 3.508195,-3.507613 3.508195,-9.221974 0,-12.728584 C 32.610756,11.8869 30.290627,11 27.985499,11 m 0,1.479833 c 1.922107,0 3.840214,0.726923 5.313295,2.19876 2.941164,2.940673 2.941164,7.679146 0,10.619819 -2.945163,2.940672 -7.684427,2.940672 -10.62959,0 -2.941164,-2.940673 -2.941164,-7.679146 0,-10.619819 1.473082,-1.47284 3.391188,-2.19876 5.316295,-2.19876 m 0,0"
+       id="path65" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#222b30;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="M 18.079,32.066 15.934,29.921 11,34.855 13.145,37"
+       id="path67" />
+    <path
+       sodipodi:nodetypes="cccccccccccc"
+       inkscape:connector-curvature="0"
+       id="path5096"
+       style="font-size:13.76537228px;font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#606060;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat Bold"
+       d="M 30.801324,24.000003 30,22 l -4,0 -0.801325,2.000003 -2.198676,0 L 27,14.000001 l 2,0 3.999999,10.000002 -2.198675,0 M 28,17 l -1.2,3 2.4,0" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for gImageReader. Fixes #1760
![gimagereader-icon](https://cloud.githubusercontent.com/assets/7050624/6765034/de9adce8-cfce-11e4-8f45-be45b8e0afb0.png)
