### PR TITLE
Icon for Gnoduino (symlink). Fixes #1768

### DIFF
--- a/Numix-Circle/48x48/apps/gnoduino.svg
+++ b/Numix-Circle/48x48/apps/gnoduino.svg
@@ -1,0 +1,1 @@
+arduino.svg


### PR DESCRIPTION
Icon for Gnoduino (symlink). Fixes #1768

Symlink to *arduino.svg*