### PR TITLE
Icon for Streamtuner2 (symlink)

### DIFF
--- a/Numix-Circle/48x48/apps/streamtuner.svg
+++ b/Numix-Circle/48x48/apps/streamtuner.svg
@@ -1,0 +1,1 @@
+radio.svg

--- a/Numix-Circle/48x48/apps/streamtuner2.svg
+++ b/Numix-Circle/48x48/apps/streamtuner2.svg
@@ -1,0 +1,1 @@
+radio.svg


### PR DESCRIPTION
Icon for Streamtuner2 (symlink). Fixes #1781

Symlinks to *radio.svg*