### PR TITLE
GUFW icon enhancement

### DIFF
--- a/Numix-Circle/48x48/apps/gufw.svg
+++ b/Numix-Circle/48x48/apps/gufw.svg
@@ -45,8 +45,8 @@
      inkscape:object-nodes="true"
      inkscape:snap-smooth-nodes="true"
      inkscape:zoom="18.085106"
-     inkscape:cx="20.10615"
-     inkscape:cy="23.555294"
+     inkscape:cx="29.758461"
+     inkscape:cy="23.610588"
      inkscape:window-x="0"
      inkscape:window-y="23"
      inkscape:window-maximized="1"
@@ -59,15 +59,15 @@
      id="defs4">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4235">
+       id="linearGradient4164">
       <stop
-         style="stop-color:#99b7e3;stop-opacity:1"
+         style="stop-color:#f49a4c;stop-opacity:1"
          offset="0"
-         id="stop4237" />
+         id="stop4166" />
       <stop
-         style="stop-color:#89acdf;stop-opacity:1"
+         style="stop-color:#f38f39;stop-opacity:1"
          offset="1"
-         id="stop4239" />
+         id="stop4168" />
     </linearGradient>
     <linearGradient
        id="linearGradient3764"
@@ -111,8 +111,8 @@
     </clipPath>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4235"
-       id="linearGradient4241"
+       xlink:href="#linearGradient4164"
+       id="linearGradient4170"
        x1="24"
        y1="1"
        x2="24"
@@ -138,13 +138,14 @@
      id="g33" />
   <g
      id="g29"
-     style="fill:#87aade">
+     style="fill:#f5a159;fill-opacity:1">
     <g
-       id="g4268">
+       id="g4268"
+       style="fill:#f5a159;fill-opacity:1">
       <path
          fill="url(#linearGradient3764)"
          fill-opacity="1"
-         style="fill:url(#linearGradient4241)"
+         style="fill:url(#linearGradient4170);fill-opacity:1"
          id="path31"
          d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" />
     </g>

--- a/Numix-Circle/48x48/apps/gufw.svg
+++ b/Numix-Circle/48x48/apps/gufw.svg
@@ -1,1 +1,204 @@
-<svg viewBox="0 0 48 48"><defs><linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)"><stop stop-color="#e4e4e4" stop-opacity="1"/><stop offset="1" stop-color="#eee" stop-opacity="1"/></linearGradient><clipPath id="clipPath-323575067"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath><clipPath id="clipPath-338686898"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath></defs><g><path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" opacity="0.05"/><path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" opacity="0.1"/><path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" opacity="0.2"/></g><g><path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" fill="url(#linearGradient3764)" fill-opacity="1"/></g><g/><g><g clip-path="url(#clipPath-323575067)"><g transform="translate(1,1)"><g opacity="0.1"><!-- color: #eeeeee --><g><path d="m 4.102 3.528 c -0.014 1 -0.013 2.01 0 3.01 c 0.013 0.968 0.056 1.722 0.441 2.314 c 0.464 0.71 1.236 1.224 2.23 1.729 c 0.992 -0.504 1.767 -1.019 2.23 -1.729 c 0.385 -0.592 0.428 -1.346 0.441 -2.314 c 0.011 -1 0.011 -2.01 0 -3.01 m -1.027 0.084 l 0.951 0 c 0.002 0.376 0.008 0.751 0.009 1.122 l -4.077 4.851 c -0.282 -0.235 -0.525 -0.485 -0.71 -0.775 c -0.085 -0.126 -0.151 -0.259 -0.205 -0.398 c 0 0 0 -0.001 0 -0.001 l 4.03 -4.799 m -0.001 0" transform="matrix(3.543307,0,0,3.543307,0,0)" stroke-opacity="1" fill="#000" fill-rule="nonzero" stroke="#ce203d" stroke-linejoin="miter" fill-opacity="1" stroke-linecap="butt" stroke-width="0.282" stroke-miterlimit="4"/></g></g></g></g></g><g><g clip-path="url(#clipPath-338686898)"><!-- color: #eeeeee --><g><path d="m 4.102 3.528 c -0.014 1 -0.013 2.01 0 3.01 c 0.013 0.968 0.056 1.722 0.441 2.314 c 0.464 0.71 1.236 1.224 2.23 1.729 c 0.992 -0.504 1.767 -1.019 2.23 -1.729 c 0.385 -0.592 0.428 -1.346 0.441 -2.314 c 0.011 -1 0.011 -2.01 0 -3.01 m -1.027 0.084 l 0.951 0 c 0.002 0.376 0.008 0.751 0.009 1.122 l -4.077 4.851 c -0.282 -0.235 -0.525 -0.485 -0.71 -0.775 c -0.085 -0.126 -0.151 -0.259 -0.205 -0.398 c 0 0 0 -0.001 0 -0.001 l 4.03 -4.799 m -0.001 0" transform="matrix(3.543307,0,0,3.543307,0,0)" stroke-opacity="1" fill="#003e70" fill-rule="nonzero" stroke="#ce203d" stroke-linejoin="miter" fill-opacity="1" stroke-linecap="butt" stroke-width="0.282" stroke-miterlimit="4"/></g></g></g><g><path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" opacity="0.1"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="gufw.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/icon.png"
+   inkscape:export-xdpi="300"
+   inkscape:export-ydpi="300">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1910"
+     inkscape:window-height="1027"
+     id="namedview59"
+     showgrid="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:zoom="18.085106"
+     inkscape:cx="20.10615"
+     inkscape:cy="23.555294"
+     inkscape:window-x="0"
+     inkscape:window-y="23"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4205" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4235">
+      <stop
+         style="stop-color:#99b7e3;stop-opacity:1"
+         offset="0"
+         id="stop4237" />
+      <stop
+         style="stop-color:#89acdf;stop-opacity:1"
+         offset="1"
+         id="stop4239" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-323575067">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-338686898">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4235"
+       id="linearGradient4241"
+       x1="24"
+       y1="1"
+       x2="24"
+       y2="47"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g29"
+     style="fill:#87aade">
+    <g
+       id="g4268">
+      <path
+         fill="url(#linearGradient3764)"
+         fill-opacity="1"
+         style="fill:url(#linearGradient4241)"
+         id="path31"
+         d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" />
+    </g>
+  </g>
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     transform="translate(-31,3)"
+     id="g4260"
+     style="opacity:0.1;fill:#000000">
+    <path
+       id="path4262"
+       d="m 46,11 0,9.100766 c 0.0485,3.431164 0.246726,6.273005 1.683191,8.371403 C 49.414412,30.988829 52.291307,33.209982 56,35 59.701231,33.213527 62.596315,30.988829 64.323805,28.472169 65.76027,26.373771 65.951496,23.53193 66,20.100766 L 66,11"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+       d="M 65,15 51.195312,30.87811 C 52.551184,32.06309 54.11678,33.070857 56,34 59.331108,32.356445 61.937448,30.318437 63.492188,28.00311 64.785005,26.072583 64.956347,23.456656 65,20.299985 Z"
+       id="path4264" />
+    <path
+       style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 47,12 0,8.299985 c 0.03487,2.521438 0.315398,4.580559 1.021484,6.33789 L 61.623047,12 Z"
+       id="path4266"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <g
+     id="g4255"
+     transform="translate(-32,2)">
+    <path
+       sodipodi:nodetypes="ccccccc"
+       inkscape:connector-curvature="0"
+       style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+       d="m 46,11 0,9.100766 c 0.0485,3.431164 0.246726,6.273005 1.683191,8.371403 C 49.414412,30.988829 52.291307,33.209982 56,35 59.701231,33.213527 62.596315,30.988829 64.323805,28.472169 65.76027,26.373771 65.951496,23.53193 66,20.100766 L 66,11"
+       id="path4203" />
+    <path
+       id="path4223"
+       d="M 65,15 51.195312,30.87811 C 52.551184,32.06309 54.11678,33.070857 56,34 59.331108,32.356445 61.937448,30.318437 63.492188,28.00311 64.785005,26.072583 64.956347,23.456656 65,20.299985 Z"
+       style="fill:#c82a2a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4207"
+       d="m 47,12 0,8.299985 c 0.03487,2.521438 0.315398,4.580559 1.021484,6.33789 L 61.623047,12 Z"
+       style="fill:#25a125;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:0.99921256;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
GUFW icon enhancement: remove strokes, change colours.

Previous icon got not coherent red strokes:
![pre-icon](https://cloud.githubusercontent.com/assets/8478202/6895376/c538a178-d6df-11e4-9e35-ebbdf422de58.png)

I've removed the strokes and remodelled the icon changin colours:
![icon](https://cloud.githubusercontent.com/assets/8478202/6895381/d43450be-d6df-11e4-8b37-094bb830626c.png)

I've used those colours cause they appear in the main menu:
![uf](https://cloud.githubusercontent.com/assets/8478202/6895395/0392f78e-d6e0-11e4-8350-8ea22ad3c919.png)

 