### PR TITLE
Icon for LaTeXDraw

### DIFF
--- a/Numix-Circle/48x48/apps/latexdraw.svg
+++ b/Numix-Circle/48x48/apps/latexdraw.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="latexdraw3b.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="22.627417"
+     inkscape:cx="24.061208"
+     inkscape:cy="23.182927"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3038" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7"
+         style="stop-color:#e4e4e4;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#a0dad0;fill-opacity:1"
+     d="m 24,1 0,7 -7,0 0,-5.90625 C 16.662644,2.2014165 16.33039,2.3148864 16,2.4375 L 16,8 9,8 9,6.5625 C 8.654277,6.8602558 8.327356,7.182486 8,7.5 L 8,8 7.5,8 C 7.182486,8.3273558 6.860256,8.6542772 6.5625,9 L 8,9 8,16 2.4375,16 C 2.3148864,16.33039 2.2014165,16.662644 2.09375,17 L 8,17 8,24 1,24 c 0,0.334333 0.017128,0.669144 0.03125,1 L 8,25 8,32 2.4375,32 c 0.1268948,0.341926 0.2637817,0.665971 0.40625,1 L 8,33 8,40 7.5,40 c 0.481443,0.496366 0.975785,0.986016 1.5,1.4375 L 9,41 l 7,0 0,4.5625 c 0.33039,0.122614 0.662644,0.236083 1,0.34375 L 17,41 l 7,0 0,6 c 0.334333,0 0.669144,-0.01713 1,-0.03125 L 25,41 l 7,0 0,4.5625 c 0.341926,-0.126895 0.665971,-0.263782 1,-0.40625 L 33,41 l 6.5,0 c 0.521894,-0.476163 1.023837,-0.978106 1.5,-1.5 l 0,-6.5 4.15625,0 c 0.142468,-0.334029 0.279355,-0.658074 0.40625,-1 L 41,32 l 0,-7 5.96875,0 C 46.982872,24.669144 47,24.334333 47,24 l -6,0 0,-7 4.90625,0 C 45.798583,16.662644 45.685114,16.33039 45.5625,16 L 41,16 41,9 41.4375,9 C 40.986016,8.4757847 40.496366,7.9814426 40,7.5 L 40,8 33,8 33,2.84375 C 32.665971,2.7012817 32.341926,2.5643948 32,2.4375 L 32,8 25,8 25,1.03125 C 24.669144,1.0171284 24.334333,1 24,1 z m -15,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z"
+     id="path31-6" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <path
+     style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
+     d="M 17 14 L 17 26.996094 L 17 27 L 21.021484 26.998047 C 21.096604 28.289078 21.459894 29.574321 22.138672 30.75 A 0.50005 0.50005 0 1 0 23.003906 30.25 C 22.414795 29.229629 22.105673 28.116431 22.03125 26.998047 L 30 26.996094 L 30 19.033203 C 31.11748 19.107778 32.230722 19.415426 33.25 20.003906 C 36.191852 21.702386 37.623338 25.160196 36.744141 28.441406 C 35.864943 31.722616 32.896958 34 29.5 34 A 0.50005 0.50005 0 0 0 29.076172 34.224609 L 24.996094 33.003906 L 12.5625 33.005859 C 12.5625 33.005859 12 33.249206 12 34.501953 C 12 35.710495 12.632812 36 12.632812 36 L 24.996094 36 L 29.076172 34.777344 A 0.50005 0.50005 0 0 0 29.5 35 C 33.344732 35 36.713894 32.412945 37.708984 28.699219 C 37.957757 27.770787 38.043028 26.830413 37.978516 25.910156 C 37.78498 23.149387 36.247227 20.580447 33.75 19.138672 C 32.575501 18.460575 31.290039 18.096806 30 18.021484 L 30 14 L 17 14 z M 18 15 L 29 15 L 29 18.017578 C 26.973535 18.137866 24.999518 18.978998 23.488281 20.490234 C 21.978016 22.0005 21.138181 23.971535 21.017578 25.996094 L 18 25.996094 L 18 15 z M 29 19.039062 L 29 25.996094 L 22.039062 25.996094 C 22.15841 24.232001 22.87606 22.516518 24.195312 21.197266 C 25.516022 19.876557 27.233316 19.157698 29 19.039062 z "
+     id="path4155" />
+  <g
+     id="g4164">
+    <path
+       transform="matrix(0,1,-1,0,0,0)"
+       sodipodi:open="true"
+       d="m 29.502182,-21.57098 a 8,8 0 0 1 -9.656854,-1.27135 8,8 0 0 1 -1.271349,-9.656854 8,8 0 0 1 8.998755,-3.727406 8,8 0 0 1 5.929448,7.727406"
+       sodipodi:end="0"
+       sodipodi:start="1.0471976"
+       sodipodi:ry="8"
+       sodipodi:rx="8"
+       sodipodi:cy="-28.499184"
+       sodipodi:cx="25.502182"
+       sodipodi:type="arc"
+       id="path4212"
+       style="fill:none;fill-opacity:0.91787438;stroke:#2d2d2d;stroke-linecap:round;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="csccc"
+       style="fill:#202e64;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       id="path85"
+       d="m 11.563,32.005994 c 0,0 -0.563,0.242757 -0.563,1.495504 C 11,34.71004 11.633,35 11.633,35 l 12.3627,0 c 0.548246,-1 0.480792,-2 0,-2.997003" />
+    <path
+       sodipodi:nodetypes="cccc"
+       style="fill:#e7ca87;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       id="path87"
+       d="m 23.9995,35 2.5,-0.749251 c 0.251703,-0.487001 0.254462,-0.819724 0,-1.498502 l -2.5,-0.74925" />
+    <path
+       sodipodi:nodetypes="ccc"
+       style="fill:#2d2d2d;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       id="path89"
+       d="m 26.4995,34.250749 2.5,-0.750749 -2.5,-0.747752" />
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0"
+       id="rect4170"
+       d="M 16,13.003906 16,26 16,26.003906 29,26 29,13.003906 Z m 1,1 11,0 L 28,25 17,25 Z"
+       style="fill:#2d2d2d;fill-opacity:1;stroke:none;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for LaTeXDraw. Fixes #1817
![latexdraw-icon](https://cloud.githubusercontent.com/assets/7050624/6946737/b55f1312-d8a2-11e4-8e86-c34bdeb4c600.png)
