### PR TITLE
Icon for SportsTracker

### DIFF
--- a/Numix-Circle/48x48/apps/sportstracker.svg
+++ b/Numix-Circle/48x48/apps/sportstracker.svg
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="sportstracker0.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="25.254345"
+     inkscape:cy="23.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#1a71a8;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#1d7db9;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path4224"
+     d="m 16.340841,14.788008 c -0.96756,0.875676 -1.045681,2.37395 -0.174488,3.346489 0.871192,0.97254 2.361795,1.051063 3.329354,0.175386 0.96756,-0.875676 1.045681,-2.37395 0.174488,-3.346489 -0.871192,-0.97254 -2.361795,-1.051063 -3.329354,-0.175386 z m -3.958912,5.496117 c -0.582335,0.527031 -0.48832,1.579632 0.210792,2.360074 l 2.523902,2.817496 c 0.699113,0.780452 1.730756,0.984453 2.3131,0.457413 l 3.153451,-2.853987 4.416812,4.930613 -2.803069,2.536882 c -0.776446,0.70272 -0.979412,1.739674 -0.455071,2.325005 0.02754,0.03071 0.06214,0.05127 0.09241,0.07829 0.273378,0.377131 0.734568,0.682181 1.30521,0.804118 l 5.532927,1.182815 c 1.021978,0.218352 1.97559,-0.225858 2.138508,-0.996291 0.162918,-0.770434 -0.528076,-1.567367 -1.550035,-1.785737 l -3.732523,-0.796973 3.466887,-3.137663 6.309741,7.04374 c 0.699112,0.780453 1.730756,0.984453 2.3131,0.457422 0.582334,-0.527039 0.488319,-1.579641 -0.210803,-2.360083 l -12.619472,-14.087482 2.102298,-1.902661 1.892929,2.113127 c 0.699112,0.780442 1.730756,0.984452 2.3131,0.457413 0.582334,-0.527041 0.488319,-1.579633 -0.210803,-2.360085 l -2.523892,-2.817495 c -0.699122,-0.780442 -1.730766,-0.984453 -2.3131,-0.457412 -1.072592,0.970739 -2.145187,1.941475 -3.217781,2.912212 -0.511706,-0.279912 -1.159002,-0.226484 -1.617797,0.188742 l -2.102298,1.902661 c -0.458795,0.415225 -0.579317,1.056706 -0.35585,1.59749 l -2.166628,1.960877 -1.892929,-2.113118 c -0.699112,-0.780451 -1.730756,-0.984453 -2.3131,-0.457412 z"
+     style="fill:#000000;fill-opacity:0.09803922"
+     sodipodi:nodetypes="ssssscsscccsccccscccsccccssssccssccscc" />
+  <path
+     style="fill:#ececec;fill-opacity:1"
+     d="m 15.340841,13.788008 c -0.96756,0.875676 -1.045681,2.37395 -0.174488,3.346489 0.871192,0.97254 2.361795,1.051063 3.329354,0.175386 0.96756,-0.875676 1.045681,-2.37395 0.174488,-3.346489 -0.871192,-0.97254 -2.361795,-1.051063 -3.329354,-0.175386 z m -3.958912,5.496117 c -0.582335,0.527031 -0.48832,1.579632 0.210792,2.360074 l 2.523902,2.817496 c 0.699113,0.780452 1.730756,0.984453 2.3131,0.457413 l 3.153451,-2.853987 4.416812,4.930613 -2.803069,2.536882 c -0.776446,0.70272 -0.979412,1.739674 -0.455071,2.325005 0.02754,0.03071 0.06214,0.05127 0.09241,0.07829 0.273378,0.377131 0.734568,0.682181 1.30521,0.804118 l 5.532927,1.182815 c 1.021978,0.218352 1.97559,-0.225858 2.138508,-0.996291 0.162918,-0.770434 -0.528076,-1.567367 -1.550035,-1.785737 l -3.732523,-0.796973 3.466887,-3.137663 6.309741,7.04374 c 0.699112,0.780453 1.730756,0.984453 2.3131,0.457422 0.582334,-0.527039 0.488319,-1.579641 -0.210803,-2.360083 l -12.619472,-14.087482 2.102298,-1.902661 1.892929,2.113127 c 0.699112,0.780442 1.730756,0.984452 2.3131,0.457413 0.582334,-0.527041 0.488319,-1.579633 -0.210803,-2.360085 l -2.523892,-2.817495 c -0.699122,-0.780442 -1.730766,-0.984453 -2.3131,-0.457412 -1.072592,0.970739 -2.145187,1.941475 -3.217781,2.912212 -0.511706,-0.279912 -1.159002,-0.226484 -1.617797,0.188742 l -2.102298,1.902661 c -0.458795,0.415225 -0.579317,1.056706 -0.35585,1.59749 l -2.166628,1.960877 -1.892929,-2.113118 c -0.699112,-0.780451 -1.730756,-0.984453 -2.3131,-0.457412 z"
+     id="rect3371"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ssssscsscccsccccscccsccccssssccssccscc" />
+</svg>


### PR DESCRIPTION
Icon for SportsTracker. Fixes #1828

Pushed:
![sportstracker](https://cloud.githubusercontent.com/assets/7050624/6973770/65d3070e-d98d-11e4-9488-4c1f4a698d8e.png)

Alt:
![sportstracker2](https://cloud.githubusercontent.com/assets/7050624/6973798/8fc10a5c-d98d-11e4-8a4f-5cd5b915d01c.png)

![sportstracker3](https://cloud.githubusercontent.com/assets/7050624/6973780/7032fc86-d98d-11e4-83c3-cc4ad06ff9aa.png)


