### PR TITLE
Icon for Kompare, fixed diffpdf icon.

### DIFF
--- a/Numix-Circle/48x48/apps/kompare.svg
+++ b/Numix-Circle/48x48/apps/kompare.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.91 r13725"
    width="100%"
    height="100%"
-   sodipodi:docname="diffpdf.svg">
+   sodipodi:docname="kompare.svg">
   <metadata
      id="metadata65">
     <rdf:RDF>
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview63"
      showgrid="false"
-     inkscape:zoom="8"
-     inkscape:cx="22.479581"
-     inkscape:cy="19.605095"
+     inkscape:zoom="1"
+     inkscape:cx="22.767475"
+     inkscape:cy="22.105095"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -61,15 +61,15 @@
      id="defs4">
     <linearGradient
        inkscape:collect="always"
-       id="linearGradient4810">
+       id="linearGradient4186">
       <stop
-         style="stop-color:#6767b3;stop-opacity:1;"
+         style="stop-color:#c23257;stop-opacity:1"
          offset="0"
-         id="stop4812" />
+         id="stop4188" />
       <stop
-         style="stop-color:#7474ba;stop-opacity:1"
+         style="stop-color:#cd3b61;stop-opacity:1"
          offset="1"
-         id="stop4814" />
+         id="stop4190" />
     </linearGradient>
     <clipPath
        id="clipPath-442087651-1-9">
@@ -99,8 +99,8 @@
     </clipPath>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4810"
-       id="linearGradient4816"
+       xlink:href="#linearGradient4186"
+       id="linearGradient4192"
        x1="1"
        y1="47"
        x2="1"
@@ -124,11 +124,16 @@
   </g>
   <path
      inkscape:connector-curvature="0"
-     style="fill:url(#linearGradient4816);fill-opacity:1"
+     style="fill:url(#linearGradient4192);fill-opacity:1"
      id="path31"
      d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 z" />
   <g
      id="g33" />
+  <path
+     id="path3450"
+     d="m 22,19 0,19 16,0 0,-16 -3,-3 -13,0 z"
+     style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none"
+     inkscape:connector-curvature="0" />
   <g
      id="g59">
     <path
@@ -148,11 +153,6 @@
      transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
      style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
      id="text3791" />
-  <path
-     id="path3450"
-     d="m 22,19 0,19 16,0 0,-16 -3,-3 -13,0 z"
-     style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none"
-     inkscape:connector-curvature="0" />
   <path
      style="fill:#eadcdc;fill-opacity:1;fill-rule:evenodd;stroke:none"
      d="M 21 18 L 21 37 L 37 37 L 37 21 L 34 18 L 21 18 z "


### PR DESCRIPTION
Icon for Kompare, Fixes #1836 
![kompare](https://cloud.githubusercontent.com/assets/7050624/6987225/63b0aa04-da45-11e4-8d0b-1c15d0adb716.png)

+Added missing shadow and gradient to the new diffpdf icon.