### PR TITLE
Icon for Shotcut

### DIFF
--- a/Numix-Circle/48x48/apps/shotcut.svg
+++ b/Numix-Circle/48x48/apps/shotcut.svg
@@ -5,16 +5,15 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="shotcut1b.svg">
+   sodipodi:docname="shotcut0b.svg">
   <metadata
-     id="metadata96">
+     id="metadata65">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -36,143 +35,127 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1366"
      inkscape:window-height="713"
-     id="namedview94"
+     id="namedview63"
      showgrid="false"
-     inkscape:zoom="11.313708"
-     inkscape:cx="32.579799"
-     inkscape:cy="20.0881"
+     inkscape:zoom="1"
+     inkscape:cx="24.038957"
+     inkscape:cy="21.966102"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
-       id="grid4251" />
+       id="grid3424" />
   </sodipodi:namedview>
   <defs
      id="defs4">
     <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4243">
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
       <stop
-         style="stop-color:#175c76;stop-opacity:1"
-         offset="0"
-         id="stop4245" />
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
       <stop
-         style="stop-color:#1a6886;stop-opacity:1"
          offset="1"
-         id="stop4247" />
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
     </linearGradient>
     <clipPath
-       id="clipPath-242030370">
+       id="clipPath-109310907">
       <g
          transform="translate(0,-1004.3622)"
-         id="g7">
+         id="g12">
         <path
            d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
            transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
            fill="#1890d0"
-           id="path9" />
+           id="path14" />
       </g>
     </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4243"
-       id="linearGradient4249"
-       x1="1"
-       y1="47"
-       x2="1"
-       y2="1"
-       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-116025689">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
   </defs>
   <g
-     id="g22">
+     id="g21">
     <path
        d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
        opacity="0.05"
-       id="path24" />
+       id="path23" />
     <path
        d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
        opacity="0.1"
-       id="path26" />
+       id="path25" />
     <path
        d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
        opacity="0.2"
-       id="path28" />
+       id="path27" />
   </g>
-  <path
-     d="m 13.001,44.187 c 3.268,1.783 7.02,2.813 11,2.813 3.985,0 7.732,-1.03 11,-2.813 8.072358,-11.158423 15.839484,-22.234662 0,-40.38 -3.268,-1.783 -7.02,-2.813 -11,-2.813 -3.985,0 -7.732,1.03 -11,2.813 -14.9320108,19.448417 -6.7117288,29.867178 0,40.38 z"
-     id="path30"
-     style="fill:url(#linearGradient4249);fill-opacity:1"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="csccscc" />
-  <path
-     style="fill:#000000;fill-opacity:0.09803922"
-     d="m 36,13 0,22 7,0 0,-22 z m 2,3 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z"
-     id="rect4287"
-     inkscape:connector-curvature="0"
-     sodipodi:nodetypes="ccccccccccccccccccccccccc" />
   <g
-     id="g32">
-    <g
-       clip-path="url(#clipPath-242030370)"
-       id="g34">
-      <g
-         transform="translate(1,1)"
-         id="g36">
-        <g
-           opacity="0.1"
-           id="g38">
-          <!-- color: #4d4d4d -->
-          <g
-             id="g40">
-            <path
-               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
-               d="M 1 -1 L 1 47 L 14 47 L 14 -1 L 1 -1 z M 8 16 L 12 16 L 12 19 L 8 19 L 8 16 z M 8 21 L 12 21 L 12 24 L 8 24 L 8 21 z M 8 26 L 12 26 L 12 29 L 8 29 L 8 26 z M 8 31 L 12 31 L 12 34 L 8 34 L 8 31 z "
-               transform="translate(-1,-1)"
-               id="path42" />
-            <path
-               d="m 16.801,15 c 0,9.898 4.5,8.102 9.703,12.293 -0.441,0.594 -0.703,1.305 -0.703,2.105 0,1.992 1.609,3.602 3.598,3.602 1.992,0 3.602,-1.609 3.602,-3.602 0.03406,-1.234163 -0.673319,-2.123656 -1.719,-3.04 M 29.399,27.6 c 0.992,0 1.801,0.809 1.801,1.797 0,0.992 -0.809,1.801 -1.801,1.801 -0.988,0 -1.797,-0.809 -1.797,-1.801 0,-0.988 0.809,-1.797 1.797,-1.797"
-               id="path62"
-               inkscape:connector-curvature="0"
-               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               sodipodi:nodetypes="ccsscccsssc" />
-            <path
-               d="m 31.2,15 c 0,9.898 -4.5,8.098 -9.703,12.293 0.441,0.598 0.703,1.305 0.703,2.105 C 22.2,31.386 20.587,33 18.598,33 16.61,33 15,31.387 15,29.398 c -0.04533,-1.228506 0.670394,-2.125211 1.718,-3.04 m 1.879,1.238 c -0.988,0 -1.801,0.813 -1.801,1.801 0,0.988 0.813,1.801 1.801,1.801 0.988,0 1.801,-0.813 1.801,-1.801 0,-0.988 -0.813,-1.801 -1.801,-1.801"
-               id="path64"
-               inkscape:connector-curvature="0"
-               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               sodipodi:nodetypes="ccsscccsssc" />
-          </g>
-        </g>
-      </g>
-    </g>
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
   </g>
-  <path
-     style="fill:#2d2d2d;fill-opacity:1;fill-rule:evenodd;stroke:none"
-     d="M 13 3.8105469 C 5.851 7.7115469 1 15.279 1 24 C 1 32.718 5.851 40.286453 13 44.189453 L 13 3.8105469 z M 7 15 L 11 15 L 11 18 L 7 18 L 7 15 z M 7 20 L 11 20 L 11 23 L 7 23 L 7 20 z M 7 25 L 11 25 L 11 28 L 7 28 L 7 25 z M 7 30 L 11 30 L 11 33 L 7 33 L 7 30 z "
-     id="path66" />
-  <path
-     style="fill:#2d2d2d;fill-opacity:1;fill-rule:evenodd;stroke:none"
-     d="M 35 3.8066406 L 35 44.177734 L 35 44.1875 C 42.149 40.2865 47 32.717094 47 23.996094 C 47 15.278094 42.149 7.7096406 35 3.8066406 z M 37 15 L 41 15 L 41 18 L 37 18 L 37 15 z M 37 20 L 41 20 L 41 23 L 37 23 L 37 20 z M 37 25 L 41 25 L 41 28 L 37 28 L 37 25 z M 37 30 L 41 30 L 41 33 L 37 33 L 37 30 z "
-     id="path76" />
-  <path
-     d="m 16.801,15 c 0,9.898 4.5,8.102 9.703,12.293 -0.441,0.594 -0.703,1.305 -0.703,2.105 0,1.992 1.609,3.602 3.598,3.602 1.992,0 3.602,-1.609 3.602,-3.602 0.03406,-1.234163 -0.673319,-2.123656 -1.719,-3.04 M 29.399,27.6 c 0.992,0 1.801,0.809 1.801,1.797 0,0.992 -0.809,1.801 -1.801,1.801 -0.988,0 -1.797,-0.809 -1.797,-1.801 0,-0.988 0.809,-1.797 1.797,-1.797"
-     id="path86"
-     inkscape:connector-curvature="0"
-     style="fill:#aaaaaa;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     sodipodi:nodetypes="ccsscccsssc" />
-  <path
-     d="m 31.2,15 c 0,9.898 -4.5,8.098 -9.703,12.293 0.441,0.598 0.703,1.305 0.703,2.105 C 22.2,31.386 20.587,33 18.598,33 16.61,33 15,31.387 15,29.398 c -0.04533,-1.228506 0.670394,-2.125211 1.718,-3.04 m 1.879,1.238 c -0.988,0 -1.801,0.813 -1.801,1.801 0,0.988 0.813,1.801 1.801,1.801 0.988,0 1.801,-0.813 1.801,-1.801 0,-0.988 -0.813,-1.801 -1.801,-1.801"
-     id="path88"
-     inkscape:connector-curvature="0"
-     style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
-     sodipodi:nodetypes="ccsscccsssc" />
   <g
-     id="g90">
+     id="g33" />
+  <g
+     id="g59">
     <path
        d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
        opacity="0.1"
-       id="path92" />
+       id="path61" />
   </g>
+  <g
+     id="g4274"
+     transform="matrix(0,1,-1,0,49,0)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:#000000;fill-opacity:0.09803922"
+       d="m 13,11 c -0.554,0 -1,0.446 -1,1 l 0,24 c 0,0.554 0.446,1 1,1 l 24,0 c 0.554,0 1,-0.446 1,-1 l 0,-24 c 0,-0.554 -0.446,-1 -1,-1 l -24,0 z m 1,2 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m -18,18 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z"
+       id="path4264" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect4223"
+       d="m 12,12 c -0.554,0 -1,0.446 -1,1 l 0,24 c 0,0.554 0.446,1 1,1 l 24,0 c 0.554,0 1,-0.446 1,-1 l 0,-24 c 0,-0.554 -0.446,-1 -1,-1 l -24,0 z m 1,2 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m -18,18 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z m 6,0 4,0 0,4 -4,0 0,-4 z"
+       style="fill:#464646;fill-opacity:1" />
+  </g>
+  <rect
+     style="fill:#175c76;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="rect3426"
+     width="10"
+     height="6"
+     x="19"
+     y="11" />
+  <rect
+     y="31"
+     x="19"
+     height="6"
+     width="10"
+     id="rect4228"
+     style="fill:#175c76;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <rect
+     style="fill:#175c76;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="rect4230"
+     width="10"
+     height="10"
+     x="19"
+     y="18.999996" />
 </svg>

--- a/Numix-Circle/48x48/apps/shotcut.svg
+++ b/Numix-Circle/48x48/apps/shotcut.svg
@@ -1,0 +1,178 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="shotcut1b.svg">
+  <metadata
+     id="metadata96">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview94"
+     showgrid="false"
+     inkscape:zoom="11.313708"
+     inkscape:cx="32.579799"
+     inkscape:cy="20.0881"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4251" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4243">
+      <stop
+         style="stop-color:#175c76;stop-opacity:1"
+         offset="0"
+         id="stop4245" />
+      <stop
+         style="stop-color:#1a6886;stop-opacity:1"
+         offset="1"
+         id="stop4247" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-242030370">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g7">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path9" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4243"
+       id="linearGradient4249"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g22">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path24" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path26" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path28" />
+  </g>
+  <path
+     d="m 13.001,44.187 c 3.268,1.783 7.02,2.813 11,2.813 3.985,0 7.732,-1.03 11,-2.813 8.072358,-11.158423 15.839484,-22.234662 0,-40.38 -3.268,-1.783 -7.02,-2.813 -11,-2.813 -3.985,0 -7.732,1.03 -11,2.813 -14.9320108,19.448417 -6.7117288,29.867178 0,40.38 z"
+     id="path30"
+     style="fill:url(#linearGradient4249);fill-opacity:1"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csccscc" />
+  <path
+     style="fill:#000000;fill-opacity:0.09803922"
+     d="m 36,13 0,22 7,0 0,-22 z m 2,3 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z m 0,5 4,0 0,3 -4,0 z"
+     id="rect4287"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccccccccccccccc" />
+  <g
+     id="g32">
+    <g
+       clip-path="url(#clipPath-242030370)"
+       id="g34">
+      <g
+         transform="translate(1,1)"
+         id="g36">
+        <g
+           opacity="0.1"
+           id="g38">
+          <!-- color: #4d4d4d -->
+          <g
+             id="g40">
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               d="M 1 -1 L 1 47 L 14 47 L 14 -1 L 1 -1 z M 8 16 L 12 16 L 12 19 L 8 19 L 8 16 z M 8 21 L 12 21 L 12 24 L 8 24 L 8 21 z M 8 26 L 12 26 L 12 29 L 8 29 L 8 26 z M 8 31 L 12 31 L 12 34 L 8 34 L 8 31 z "
+               transform="translate(-1,-1)"
+               id="path42" />
+            <path
+               d="m 16.801,15 c 0,9.898 4.5,8.102 9.703,12.293 -0.441,0.594 -0.703,1.305 -0.703,2.105 0,1.992 1.609,3.602 3.598,3.602 1.992,0 3.602,-1.609 3.602,-3.602 0.03406,-1.234163 -0.673319,-2.123656 -1.719,-3.04 M 29.399,27.6 c 0.992,0 1.801,0.809 1.801,1.797 0,0.992 -0.809,1.801 -1.801,1.801 -0.988,0 -1.797,-0.809 -1.797,-1.801 0,-0.988 0.809,-1.797 1.797,-1.797"
+               id="path62"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="ccsscccsssc" />
+            <path
+               d="m 31.2,15 c 0,9.898 -4.5,8.098 -9.703,12.293 0.441,0.598 0.703,1.305 0.703,2.105 C 22.2,31.386 20.587,33 18.598,33 16.61,33 15,31.387 15,29.398 c -0.04533,-1.228506 0.670394,-2.125211 1.718,-3.04 m 1.879,1.238 c -0.988,0 -1.801,0.813 -1.801,1.801 0,0.988 0.813,1.801 1.801,1.801 0.988,0 1.801,-0.813 1.801,-1.801 0,-0.988 -0.813,-1.801 -1.801,-1.801"
+               id="path64"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="ccsscccsssc" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <path
+     style="fill:#2d2d2d;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="M 13 3.8105469 C 5.851 7.7115469 1 15.279 1 24 C 1 32.718 5.851 40.286453 13 44.189453 L 13 3.8105469 z M 7 15 L 11 15 L 11 18 L 7 18 L 7 15 z M 7 20 L 11 20 L 11 23 L 7 23 L 7 20 z M 7 25 L 11 25 L 11 28 L 7 28 L 7 25 z M 7 30 L 11 30 L 11 33 L 7 33 L 7 30 z "
+     id="path66" />
+  <path
+     style="fill:#2d2d2d;fill-opacity:1;fill-rule:evenodd;stroke:none"
+     d="M 35 3.8066406 L 35 44.177734 L 35 44.1875 C 42.149 40.2865 47 32.717094 47 23.996094 C 47 15.278094 42.149 7.7096406 35 3.8066406 z M 37 15 L 41 15 L 41 18 L 37 18 L 37 15 z M 37 20 L 41 20 L 41 23 L 37 23 L 37 20 z M 37 25 L 41 25 L 41 28 L 37 28 L 37 25 z M 37 30 L 41 30 L 41 33 L 37 33 L 37 30 z "
+     id="path76" />
+  <path
+     d="m 16.801,15 c 0,9.898 4.5,8.102 9.703,12.293 -0.441,0.594 -0.703,1.305 -0.703,2.105 0,1.992 1.609,3.602 3.598,3.602 1.992,0 3.602,-1.609 3.602,-3.602 0.03406,-1.234163 -0.673319,-2.123656 -1.719,-3.04 M 29.399,27.6 c 0.992,0 1.801,0.809 1.801,1.797 0,0.992 -0.809,1.801 -1.801,1.801 -0.988,0 -1.797,-0.809 -1.797,-1.801 0,-0.988 0.809,-1.797 1.797,-1.797"
+     id="path86"
+     inkscape:connector-curvature="0"
+     style="fill:#aaaaaa;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:nodetypes="ccsscccsssc" />
+  <path
+     d="m 31.2,15 c 0,9.898 -4.5,8.098 -9.703,12.293 0.441,0.598 0.703,1.305 0.703,2.105 C 22.2,31.386 20.587,33 18.598,33 16.61,33 15,31.387 15,29.398 c -0.04533,-1.228506 0.670394,-2.125211 1.718,-3.04 m 1.879,1.238 c -0.988,0 -1.801,0.813 -1.801,1.801 0,0.988 0.813,1.801 1.801,1.801 0.988,0 1.801,-0.813 1.801,-1.801 0,-0.988 -0.813,-1.801 -1.801,-1.801"
+     id="path88"
+     inkscape:connector-curvature="0"
+     style="fill:#cccccc;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     sodipodi:nodetypes="ccsscccsssc" />
+  <g
+     id="g90">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path92" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Shotcut. Fixes #1840

Pushed:
![shotcut](https://cloud.githubusercontent.com/assets/7050624/6987360/8fe41ff6-da46-11e4-937b-938936774582.png)
Alt:
![shotcut1](https://cloud.githubusercontent.com/assets/7050624/6987364/959c85aa-da46-11e4-80d0-de3fb6423a19.png)
![shotcut0b](https://cloud.githubusercontent.com/assets/7050624/6987366/9a70e396-da46-11e4-9f28-df9d5bc88117.png)


