### PR TITLE
Icon for Tetzle

### DIFF
--- a/Numix-Circle/48x48/apps/tetzle.svg
+++ b/Numix-Circle/48x48/apps/tetzle.svg
@@ -1,0 +1,162 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="tetzle3b.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="19.164604"
+     inkscape:cy="29.037034"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer3"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4" />
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="opacity:1;fill:#e6e6e6;fill-opacity:1;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(4.3274075,0,0,3.2455556,117.12222,-35.418889)" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol">
+    <g
+       id="g3373">
+      <path
+         style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none;stroke-width:0.28222224px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 4.797778,5.3622228 0,-1.4111114 4.5155557,0 0,2.8222225 1.4111113,0 0,3.1044442 -1.6933335,0 0,-1.4111112 -1.1288889,4e-7 0,1.4111108 -3.1044446,0 0,-1.4111112 -1.4111112,4e-7 0,-3.1044446 z"
+         id="path3383"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccccccccc" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="rect4388"
+         d="m 4.5155557,5.0800002 0,-1.4111114 4.5155557,0 0,2.8222225 1.4111116,0 0,3.1044442 -1.6933338,0 0,-1.4111112 -1.1288889,4e-7 0,1.4111108 -3.1044446,0 0,-1.4111112 -1.4111112,4e-7 0,-3.1044446 z"
+         style="fill:#555555;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.28222224px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <g
+         id="g3365">
+        <g
+           id="g3359">
+          <path
+             inkscape:connector-curvature="0"
+             id="rect4885"
+             transform="scale(0.28222223,0.28222223)"
+             d="m 16,14 0,4 -4,0 0,11 4,0 0,4 11,0 0,-4 4,0 0,4 5,0 0,-10 -4,0 0,-9 -16,0 z"
+             style="fill:#64b3d2;fill-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4887"
+             transform="scale(0.28222223,0.28222223)"
+             d="M 30.544922,21.388672 17.761719,33 27,33 l 0,-4 4,0 0,4 5,0 0,-6.333984 L 32.210938,23 32,23 32,22.796875 30.544922,21.388672 Z"
+             style="fill:#43a63b;fill-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4889"
+             transform="scale(0.28222223,0.28222223)"
+             d="M 19.203125,15.583984 A 3.8181818,3.6944446 0 0 0 16,17.115234 L 16,18 15.513672,18 a 3.8181818,3.6944446 0 0 0 -0.240234,1.277344 3.8181818,3.6944446 0 0 0 7.634765,0 3.8181818,3.6944446 0 0 0 -3.705078,-3.69336 z"
+             style="fill:#f3da4d;fill-opacity:1" />
+          <path
+             inkscape:connector-curvature="0"
+             id="path4891"
+             transform="scale(0.28222223,0.28222223)"
+             d="M 20.726562,20.333984 12.927734,29 16,29 l 0,4 11,0 0,-4 0.443359,0 -6.716797,-8.666016 z"
+             style="fill:#269542;fill-opacity:1" />
+        </g>
+        <path
+           style="fill:#4d4d4d;fill-opacity:0.21568627;stroke:none"
+           d="m 16,14 0,4 -4,0 0,1 4,0 0,4 -4,0 0,1 4,0 0,4 -4,0 0,1 4,0 0,4 1,0 0,-4 4,0 0,4 1,0 0,-4 4,0 0,4 1,0 0,-4 4,0 0,4 1,0 0,-4 4,0 0,-1 -4,0 0,-4 4,0 0,-1 -4,0 0,-9 -1,0 0,4 -4,0 0,-4 -1,0 0,4 -4,0 0,-4 -1,0 0,4 -4,0 0,-4 z m 1,5 4,0 0,4 -4,0 z m 5,0 4,0 0,4 -4,0 z m 5,0 4,0 0,4 -4,0 z m -10,5 4,0 0,4 -4,0 z m 5,0 4,0 0,4 -4,0 z m 5,0 4,0 0,4 -4,0 z"
+           transform="scale(0.28222223,0.28222223)"
+           id="rect5192"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Tetzle. Fixes #1864

Pushed:
![tetzle](https://cloud.githubusercontent.com/assets/7050624/7027849/436ae3d0-dd52-11e4-9bbe-ea7caa0f3b86.png)

Alt:
![tetzle1](https://cloud.githubusercontent.com/assets/7050624/7027854/47e0752e-dd52-11e4-912f-c3f25fdae121.png)

