### PR TITLE
Icon for Diskmonitor (symlink)

### DIFF
--- a/Numix-Circle/48x48/apps/diskmonitor.svg
+++ b/Numix-Circle/48x48/apps/diskmonitor.svg
@@ -1,0 +1,1 @@
+gsmartcontrol.svg


### PR DESCRIPTION
Icon for Diskmonitor. Fixes #1883

Symlink to *gsmartcontrol.svg*