### PR TITLE
Icon for KSquares (symlink)

### DIFF
--- a/Numix-Circle/48x48/apps/ksquares.svg
+++ b/Numix-Circle/48x48/apps/ksquares.svg
@@ -1,0 +1,1 @@
+chrome-ieicmdpibfnjbmjolkmohnelljmjomoj-Default.svg


### PR DESCRIPTION
Fixes #1890
Symlink to a tetris clone chrome app icon