### PR TITLE
Icon for Gambit (symlink)

### DIFF
--- a/Numix-Circle/48x48/apps/gambitchess.svg
+++ b/Numix-Circle/48x48/apps/gambitchess.svg
@@ -1,0 +1,1 @@
+knights.svg


### PR DESCRIPTION
Icon for Gambit (symlink). Fixes #1894
Symlink to *knights.svg*