### PR TITLE
Symlinks for Zeegaree

### DIFF
--- a/Numix-Circle/48x48/apps/zeegaree-lite.svg
+++ b/Numix-Circle/48x48/apps/zeegaree-lite.svg
@@ -1,0 +1,1 @@
+zeegaree.svg

--- a/Numix-Circle/48x48/apps/zeegaree.svg
+++ b/Numix-Circle/48x48/apps/zeegaree.svg
@@ -1,0 +1,1 @@
+kronometer.svg


### PR DESCRIPTION
Symlinks for Zeegaree. Fixes #945

Symlinks to *kronometer.svg*

Alternatively it could be linked to *indicator-remindor.svg*, *preferences-system-time.svg*, *pomidor.svg* or *gnome-clocks.svg*.