### PR TITLE
Icon for Boomaga

### DIFF
--- a/Numix-Circle/48x48/apps/boomaga.svg
+++ b/Numix-Circle/48x48/apps/boomaga.svg
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="boomaga0.svg">
+  <metadata
+     id="metadata69">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="640"
+     inkscape:window-height="480"
+     id="namedview67"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="0"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#219ccf"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#27a6dc"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-178411873">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-7">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-6" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-165424667">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-1">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-7" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g63">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path65" />
+  </g>
+  <g
+     id="g35">
+    <g
+       clip-path="url(#clipPath-165424667)"
+       id="g37">
+      <g
+         transform="translate(1,1)"
+         id="g39">
+        <g
+           style="opacity:0.1"
+           id="g41">
+          <!-- color: #61ced7 -->
+          <g
+             id="g43">
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 12.773,17 22.453,0 c 0.98,0 1.773,0.793 1.773,1.773 l 0,12.453 c 0,0.98 -0.793,1.773 -1.773,1.773 l -22.453,0 C 11.793,32.999 11,32.206 11,31.226 L 11,18.773 C 11,17.793 11.793,17 12.773,17 m 0,0"
+               id="path45" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 11,25 0,6.219 C 11,32.199 11.801,33 12.781,33 l 22.438,0 C 36.199,33 37,32.199 37,31.219 L 37,25 m -26,0"
+               id="path47" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 15,20 18,0 0,2 -18,0 m 0,-2"
+               id="path49" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="M 16.875,11 C 16.383,11 16,11.383 16,11.875 l 0,9.125 16,0 0,-7 -3,-3 m -12.12,0"
+               id="path51" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 15,28 18,0 0,2 -18,0 m 0,-2"
+               id="path53" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 32,29 0,7.113 C 32,36.605 31.605,37 31.113,37 l -14.227,0 c -0.492,0 -0.887,-0.395 -0.887,-0.887 l 0,-7.113 m 16,0"
+               id="path55" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 29,11 0,3 3,0 m -3,-3"
+               id="path57" />
+            <use
+               height="100%"
+               width="100%"
+               y="0"
+               x="0"
+               xlink:href="#SVGCleanerId_0"
+               id="use59" />
+            <path
+               style="fill:#000000;fill-opacity:0.70200004;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19,13 9,0 0,1 -9,0 m 0,-1"
+               id="path61" />
+            <path
+               style="fill:#000000;fill-opacity:0.70200004;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19,15 9,0 0,1 -9,0 m 0,-1"
+               id="path63" />
+            <path
+               style="fill:#000000;fill-opacity:0.70200004;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19,17 9,0 0,1 -9,0 m 0,-1"
+               id="path65-7" />
+            <path
+               style="fill:#000000;fill-opacity:0.70200004;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19,19 6,0 0,1 -6,0 m 0,-1"
+               id="path67" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g69">
+    <g
+       clip-path="url(#clipPath-178411873)"
+       id="g71">
+      <!-- color: #61ced7 -->
+      <g
+         id="g73">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 12.773,17 22.453,0 c 0.98,0 1.773,0.793 1.773,1.773 l 0,12.453 c 0,0.98 -0.793,1.773 -1.773,1.773 l -22.453,0 C 11.793,32.999 11,32.206 11,31.226 L 11,18.773 C 11,17.793 11.793,17 12.773,17 m 0,0"
+           id="path75"
+           style="fill:#737481;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           inkscape:connector-curvature="0"
+           style="fill:#3e4a5c;fill-opacity:1"
+           d="m 11,25 0,6.21875 C 11,32.19875 11.80125,33 12.78125,33 l 22.4375,0 C 36.19875,33 37,32.19875 37,31.21875 L 37,25 11,25 Z m 4,3 18,0 0,2 -18,0 0,-2 z"
+           id="path77" />
+        <path
+           inkscape:connector-curvature="0"
+           d="m 15,20 18,0 0,2 -18,0 m 0,-2"
+           id="path79"
+           style="fill:#3e4a5c;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#ececde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="M 16.875,11 C 16.383,11 16,11.383 16,11.875 l 0,9.125 16,0 0,-7 -3,-3 m -12.12,0"
+           id="path81" />
+        <path
+           style="fill:#ececde;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 32,29 0,7.113 C 32,36.605 31.605,37 31.113,37 l -14.227,0 c -0.492,0 -0.887,-0.395 -0.887,-0.887 l 0,-7.113 m 16,0"
+           id="path85" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 29,11 0,3 3,0 m -3,-3"
+           id="path87" />
+        <path
+           style="fill:#000000;fill-opacity:0.2;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 29,14 3,0 0,3 m -3,-3"
+           id="SVGCleanerId_0" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Boomaga. Fixes #1933
![boomaga-icon](https://cloud.githubusercontent.com/assets/7050624/7101684/4c1413a6-e065-11e4-9ec4-30a6f6b536a3.png)
Alt:
![boomaga3](https://cloud.githubusercontent.com/assets/7050624/7101687/50e5e986-e065-11e4-99af-f21e42c7d596.png)
