### PR TITLE
Even more KDE stuff

### DIFF
--- a/Numix-Circle/48x48/apps/cirkuit.svg
+++ b/Numix-Circle/48x48/apps/cirkuit.svg
@@ -1,0 +1,1 @@
+latexdraw.svg

--- a/Numix-Circle/48x48/apps/kdesvn.svg
+++ b/Numix-Circle/48x48/apps/kdesvn.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kdesvn.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="24.250001"
+     inkscape:cy="21.928932"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3346" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#97b2d3"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#a5bcd9"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <path
+     style="fill:#000000;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:0.09803922"
+     d="m 21,12 a 3,3 0 0 0 -3,3 3,3 0 0 0 0.689453,1.908203 l -3.091797,5.152344 a 3,3 0 0 1 -0.002,0 A 3,3 0 0 0 15,22 a 3,3 0 0 0 -3,3 3,3 0 0 0 3,3 3,3 0 0 0 0.595703,-0.0625 L 18.6875,33.089844 A 3,3 0 0 0 18,35 a 3,3 0 0 0 3,3 3,3 0 0 0 2.824219,-2 l 8.349609,0 A 3,3 0 0 0 35,38 a 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 3,3 0 0 0 -2.824219,2 l -8.349609,0 A 3,3 0 0 0 21,32 3,3 0 0 0 20.404297,32.0625 L 17.3125,26.910156 A 3,3 0 0 0 17.824219,26 l 8.349609,0 A 3,3 0 0 0 29,28 a 3,3 0 0 0 3,-3 3,3 0 0 0 -3,-3 3,3 0 0 0 -2.824219,2 l -8.349609,0 a 3,3 0 0 0 -0.515625,-0.908203 l 3.091797,-5.152344 A 3,3 0 0 0 21,18 3,3 0 0 0 24,15 3,3 0 0 0 21,12 Z"
+     id="circle4195"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g4185">
+    <circle
+       r="3"
+       cy="24"
+       cx="14"
+       id="path3348"
+       style="fill:#f0f0f0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
+    <circle
+       style="fill:#f0f0f0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       id="circle4168"
+       cx="28"
+       cy="24"
+       r="3" />
+    <circle
+       r="3"
+       cy="14"
+       cx="20"
+       id="circle4170"
+       style="fill:#f0f0f0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
+    <circle
+       style="fill:#f0f0f0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1"
+       id="circle4172"
+       cx="20"
+       cy="34"
+       r="3" />
+    <circle
+       r="3"
+       cy="34"
+       cx="34"
+       id="circle4174"
+       style="fill:#f0f0f0;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;fill-opacity:1" />
+    <path
+       id="path4176"
+       d="M 19.142578 13.486328 L 12.833984 24 L 19.433594 35 L 34 35 L 34 33 L 20.566406 33 L 15.765625 25 L 28 25 L 28 23 L 15.765625 23 L 20.857422 14.513672 L 19.142578 13.486328 z "
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f0f0f0;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+  <g
+     id="g4193"
+     style="fill:#000000" />
+</svg>

--- a/Numix-Circle/48x48/apps/kfilereplace.svg
+++ b/Numix-Circle/48x48/apps/kfilereplace.svg
@@ -1,0 +1,1 @@
+rename.svg

--- a/Numix-Circle/48x48/apps/kiten.svg
+++ b/Numix-Circle/48x48/apps/kiten.svg
@@ -1,0 +1,1 @@
+jiten.svg

--- a/Numix-Circle/48x48/apps/kscd.svg
+++ b/Numix-Circle/48x48/apps/kscd.svg
@@ -1,0 +1,1 @@
+goobox.svg

--- a/Numix-Circle/48x48/apps/kst.svg
+++ b/Numix-Circle/48x48/apps/kst.svg
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="kst.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:zoom="1"
+     inkscape:cx="18.075085"
+     inkscape:cy="23.397709"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3038" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#a0dad0;fill-opacity:1"
+     d="m 24,1 0,7 -7,0 0,-5.90625 C 16.662644,2.2014165 16.33039,2.3148864 16,2.4375 L 16,8 9,8 9,6.5625 C 8.654277,6.8602558 8.327356,7.182486 8,7.5 L 8,8 7.5,8 C 7.182486,8.3273558 6.860256,8.6542772 6.5625,9 L 8,9 8,16 2.4375,16 C 2.3148864,16.33039 2.2014165,16.662644 2.09375,17 L 8,17 8,24 1,24 c 0,0.334333 0.017128,0.669144 0.03125,1 L 8,25 8,32 2.4375,32 c 0.1268948,0.341926 0.2637817,0.665971 0.40625,1 L 8,33 8,40 7.5,40 c 0.481443,0.496366 0.975785,0.986016 1.5,1.4375 L 9,41 l 7,0 0,4.5625 c 0.33039,0.122614 0.662644,0.236083 1,0.34375 L 17,41 l 7,0 0,6 c 0.334333,0 0.669144,-0.01713 1,-0.03125 L 25,41 l 7,0 0,4.5625 c 0.341926,-0.126895 0.665971,-0.263782 1,-0.40625 L 33,41 l 6.5,0 c 0.521894,-0.476163 1.023837,-0.978106 1.5,-1.5 l 0,-6.5 4.15625,0 c 0.142468,-0.334029 0.279355,-0.658074 0.40625,-1 L 41,32 l 0,-7 5.96875,0 C 46.982872,24.669144 47,24.334333 47,24 l -6,0 0,-7 4.90625,0 C 45.798583,16.662644 45.685114,16.33039 45.5625,16 L 41,16 41,9 41.4375,9 C 40.986016,8.4757847 40.496366,7.9814426 40,7.5 L 40,8 33,8 33,2.84375 C 32.665971,2.7012817 32.341926,2.5643948 32,2.4375 L 32,8 25,8 25,1.03125 C 24.669144,1.0171284 24.334333,1 24,1 z m -15,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m -24,8 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z m 8,0 7,0 0,7 -7,0 0,-7 z"
+     id="path31-6" />
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:#666666"
+     d="m 24,1 0,23 -23,0 c 0,0.335398 0.011179,0.668102 0.025391,1 L 24,25 24,47 c 0.335398,0 0.668102,-0.01118 1,-0.02539 L 25,25 46.974609,25 C 46.988821,24.668102 47,24.335398 47,24 L 25,24 25,1.0253906 C 24.668102,1.0111793 24.335398,1 24,1 Z"
+     id="path31-8" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     id="g5322">
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none;stroke-width:1.49994361;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 35.546875,38 -0.04492,-0.703125 c -0.348026,-5.623611 -0.91874,-9.480003 -1.628906,-11.958984 -0.710166,-2.478982 -1.554794,-3.467532 -2.193359,-3.703125 -0.319283,-0.117797 -0.647545,-0.108565 -1.083985,0.04687 -0.43644,0.15544 -0.954294,0.471823 -1.503906,0.912109 -1.099224,0.880572 -2.321208,2.241092 -3.554688,3.623047 -1.233479,1.381955 -2.476733,2.78425 -3.734375,3.787109 -0.62882,0.50143 -1.263662,0.909239 -1.9375,1.144532 -0.673838,0.235292 -1.413935,0.283555 -2.105468,0.01953 C 16.3767,30.639914 15.423781,29.110992 14.666018,26.427728 13.908252,23.744471 13.344153,19.704671 13,14 l 1.498047,0 c 0.340679,5.647088 0.906066,9.522178 1.611328,12.019531 0.705262,2.497354 1.549206,3.505095 2.185547,3.748047 0.31817,0.121476 0.6428,0.114217 1.076172,-0.03711 0.433372,-0.151326 0.947925,-0.461321 1.496094,-0.898438 1.096336,-0.874233 2.317524,-2.231576 3.550781,-3.613281 1.233256,-1.381705 2.47787,-2.788743 3.736328,-3.796875 0.629229,-0.504066 1.263952,-0.912457 1.9375,-1.152344 0.673548,-0.239886 1.413296,-0.297107 2.107422,-0.04102 1.388251,0.51219 2.351262,2.030469 3.115234,4.697271 C 36.078425,27.592583 36.648378,32.318297 37,38 c -1.011049,-0.01519 -1,0 -1.453125,0 z"
+       id="path4217"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssssssssccssssssssscc" />
+    <path
+       sodipodi:nodetypes="ccsssssssssccssssssssscc"
+       inkscape:connector-curvature="0"
+       id="path4209"
+       d="m 34.546875,37 -0.04492,-0.703125 c -0.348026,-5.623611 -0.91874,-9.480003 -1.628906,-11.958984 -0.710166,-2.478982 -1.554794,-3.467532 -2.193359,-3.703125 -0.319283,-0.117797 -0.647545,-0.108565 -1.083985,0.04687 -0.43644,0.15544 -0.954294,0.471823 -1.503906,0.912109 -1.099224,0.880572 -2.321208,2.241092 -3.554688,3.623047 -1.233479,1.381955 -2.476733,2.78425 -3.734375,3.787109 -0.62882,0.50143 -1.263662,0.909239 -1.9375,1.144532 -0.673838,0.235292 -1.413935,0.283555 -2.105468,0.01953 C 15.3767,29.639914 14.423781,28.110992 13.666018,25.427728 12.908252,22.744471 12.344153,18.704671 12,13 l 1.498047,0 c 0.340679,5.647088 0.906066,9.522178 1.611328,12.019531 0.705262,2.497354 1.549206,3.505095 2.185547,3.748047 0.31817,0.121476 0.6428,0.114217 1.076172,-0.03711 0.433372,-0.151326 0.947925,-0.461321 1.496094,-0.898438 1.096336,-0.874233 2.317524,-2.231576 3.550781,-3.613281 1.233256,-1.381705 2.47787,-2.788743 3.736328,-3.796875 0.629229,-0.504066 1.263952,-0.912457 1.9375,-1.152344 0.673548,-0.239886 1.413296,-0.297107 2.107422,-0.04102 1.388251,0.51219 2.351262,2.030469 3.115234,4.697271 C 35.078425,26.592583 35.648378,31.318297 36,37 c -1.011049,-0.01519 -1,0 -1.453125,0 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#e04c4c;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.49994361;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+</svg>


### PR DESCRIPTION
Even more KDE stuff. Fixes #1959

+ Cirkuit
   Symlink to *latexdraw.svg*

+ KDEsvn
![kdesvn](https://cloud.githubusercontent.com/assets/7050624/7164948/553c49ac-e3a4-11e4-9d00-db53a8ff73b6.png)


+ KFileReplace
   Symlink to *rename.svg*

+ Kiten
   Symlink to *jiten.svg*

+ KsCD
   Symlink to *goobox.svg*


+  KSt
![kst](https://cloud.githubusercontent.com/assets/7050624/7164962/76570d48-e3a4-11e4-87f9-977cd6be6228.png)



