### PR TITLE
Icon for KAudioCreator

### DIFF
--- a/Numix-Circle/48x48/apps/kaudiocreator.svg
+++ b/Numix-Circle/48x48/apps/kaudiocreator.svg
@@ -1,0 +1,291 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kaudiocreator.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="4.9166667"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#75ac40"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#7eba45"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-588316483">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3096">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path3098" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linear0"
+       gradientUnits="userSpaceOnUse"
+       y1="279.10001"
+       x2="0"
+       y2="268.32999"
+       gradientTransform="matrix(2.797157,0,0,2.797157,-332.97333,-741.65338)">
+      <stop
+         stop-color="#c8c8c8"
+         stop-opacity="1"
+         id="stop3101" />
+      <stop
+         offset="1"
+         stop-color="#eaeaea"
+         stop-opacity="1"
+         id="stop3103" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-124071972">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12-0">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path14-6" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-137054130">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-1">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-9" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     id="g4387">
+    <g
+       id="g3703"
+       transform="scale(3.543307,3.543307)">
+      <g
+         transform="scale(0.28222223,0.28222223)"
+         id="g4119">
+        <g
+           id="g5381">
+          <g
+             id="g3157">
+            <g
+               clip-path="url(#clipPath-588316483)"
+               id="g3159">
+              <!-- color: #409bcb -->
+              <g
+                 id="g3161">
+                <path
+                   id="path3728"
+                   d="m 25,10.003906 c -8.285,0 -15,6.715 -15,15 C 10,33.284906 16.715,40 25,40 c 8.281,0 14.996094,-6.715094 14.996094,-14.996094 0,-8.285 -6.715094,-15 -14.996094,-15 z m 0,12.859375 c 0.59,0 1.128625,0.238094 1.515625,0.621094 0.387,0.387 0.625,0.925531 0.625,1.519531 0,0.59 -0.238001,1.128625 -0.625,1.515625 -0.387,0.387 -0.925625,0.625 -1.515625,0.625 -0.594,0 -1.132531,-0.238 -1.519531,-0.625 -0.383001,-0.387 -0.621094,-0.925625 -0.621094,-1.515625 0,-0.594 0.238094,-1.132531 0.621094,-1.519531 0.387,-0.383 0.925531,-0.621094 1.519531,-0.621094 z"
+                   style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none"
+                   inkscape:connector-curvature="0" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:url(#linear0);fill-rule:evenodd;stroke:none"
+                   d="M 24,9 C 15.715,9 9,15.715 9,24 9,32.281 15.715,38.996094 24,38.996094 32.281,38.996094 38.996094,32.281 38.996094,24 38.996094,15.715 32.281,9 24,9 Z m 0,12.859375 c 0.59,0 1.128625,0.238094 1.515625,0.621094 0.387,0.387 0.625,0.925531 0.625,1.519531 0,0.59 -0.238001,1.128625 -0.625,1.515625 -0.387,0.387 -0.925625,0.625 -1.515625,0.625 -0.594,0 -1.132531,-0.238 -1.519531,-0.625 C 22.097468,25.128625 21.859375,24.59 21.859375,24 c 0,-0.594 0.238094,-1.132531 0.621094,-1.519531 0.387,-0.383 0.925531,-0.621094 1.519531,-0.621094 z"
+                   id="path3163" />
+                <path
+                   d="m 34.47,34.68 c 0.691,-0.682248 1.313,-1.438546 1.863,-2.24125 0.547,-0.798754 1.023,-1.666621 1.41,-2.569045 0.387,-0.902424 0.68,-1.847303 0.883,-2.830689 C 38.825,26.055631 38.935,25.037689 38.935,24 L 28.3,24 c 0,0.624983 -0.16,1.22627 -0.39,1.766342 -0.227,0.540072 -0.616,1.02584 -1.03,1.434597 l 7.594,7.478074"
+                   id="path3165"
+                   inkscape:connector-curvature="0"
+                   style="fill:#ffffff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   sodipodi:nodetypes="ccscccccc" />
+                <path
+                   d="m 13.496,13.289 c -0.688,0.683723 -1.309,1.439992 -1.855,2.247939 -0.547,0.807946 -1.02,1.673531 -1.402,2.577874 C 9.852,19.019156 9.559,19.966232 9.36,20.949084 9.157,21.934918 9.051,22.956527 9.051,24 l 10.664,0 c 0,-0.629065 0.125,-1.230304 0.359,-1.769929 0.23,-0.543599 0.563,-1.032541 0.973,-1.439992 l -7.539,-7.49611 m -0.012,-0.004"
+                   id="path3167"
+                   inkscape:connector-curvature="0"
+                   style="fill:#ffffff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none" />
+                <path
+                   d="m 10.343,30.207 c 0.75,1.652 1.793,3.133 3.059,4.398 l 7.558,-7.566 c -0.359,-0.363 -0.669,-0.801 -0.88,-1.273"
+                   id="path3171"
+                   inkscape:connector-curvature="0"
+                   style="fill:#ffffff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   sodipodi:nodetypes="cccc" />
+                <path
+                   d="M 34.602,13.398 27.04,20.96 c 0.363,0.363 0.67,0.801 0.885,1.273 l 9.736,-4.445 C 36.907,16.14 35.868,14.659 34.602,13.393"
+                   id="path3173"
+                   inkscape:connector-curvature="0"
+                   style="fill:#ffffff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   sodipodi:nodetypes="ccccc" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:#999999;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   d="m 28.289062,24 c 0,0.397173 -0.07081,0.773723 -0.171874,1.138672 L 38.464844,28 C 38.819844,26.698213 39,25.353134 39,24 l -10.710938,0 z"
+                   id="path3175" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:#999999;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   d="M 9.5351562,20.027344 C 9.1801563,21.320344 9,22.656 9,24 l 10.720703,0 c 0,-0.393491 0.06871,-0.766981 0.167969,-1.128906 L 9.5351562,20.027344 Z"
+                   id="path3177" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:#ff8dff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   d="m 24,9 0,10.714844 c 0.002,-3e-6 0.0039,0 0.0059,0 0.392045,0 0.764266,0.06941 1.125,0.167968 L 27.972656,9.5351562 C 26.679656,9.1801563 25.344,9 24,9 Z"
+                   id="path3179" />
+                <path
+                   inkscape:connector-curvature="0"
+                   style="fill:#ff8dff;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+                   d="m 22.871094,28.113281 -2.84375,10.351563 C 21.320344,38.819844 22.656,39 24,39 l 0,-10.714844 c -0.392964,-5.33e-4 -0.767505,-0.07234 -1.128906,-0.171875 z"
+                   id="path3181" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           transform="matrix(0.31934807,-0.31881336,0.30825822,0.27739353,1.8873265,21.743744)"
+           id="g46">
+          <g
+             id="g48"
+             clip-path="url(#clipPath-124071972)">
+            <g
+               id="g50"
+               transform="translate(1,1)">
+              <g
+                 style="opacity:0.1"
+                 id="g52">
+                <!-- color: #5173bf -->
+                <g
+                   id="g54" />
+              </g>
+            </g>
+          </g>
+        </g>
+        <g
+           transform="matrix(0.32013076,-0.32490868,0.30901372,0.28269696,1.9750363,21.295182)"
+           id="g74">
+          <g
+             id="g76"
+             clip-path="url(#clipPath-137054130)">
+            <!-- color: #5173bf -->
+            <g
+               id="g78" />
+          </g>
+        </g>
+      </g>
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#999999;fill-opacity:0.49800002;fill-rule:nonzero;stroke:none"
+         d="m 24.005859,19.714844 c -2.367,0 -4.285156,1.918156 -4.285156,4.285156 0,2.367 1.918156,4.285156 4.285156,4.285156 2.367,0 4.283203,-1.918156 4.283203,-4.285156 0,-2.367 -1.916203,-4.285156 -4.283203,-4.285156 z M 24,21.859375 c 0.59,0 1.128625,0.238094 1.515625,0.621094 0.387,0.387 0.625,0.925531 0.625,1.519531 0,0.59 -0.238001,1.128625 -0.625,1.515625 -0.387,0.387 -0.925625,0.625 -1.515625,0.625 -0.594,0 -1.132531,-0.238 -1.519531,-0.625 C 22.097468,25.128625 21.859375,24.59 21.859375,24 c 0,-0.594 0.238094,-1.132531 0.621094,-1.519531 0.387,-0.383 0.925531,-0.621094 1.519531,-0.621094 z"
+         transform="scale(0.28222223,0.28222223)"
+         id="path96" />
+    </g>
+    <g
+       id="g4381">
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none"
+         d="m 32.441406,23.005859 c -2.295937,-0.05916 -3.930062,0.276579 -5.945312,1.580079 l 0,7.484374 C 26.336399,32.029277 26.172543,32 26,32 c -1.105,0 -2,0.895 -2,2 0,1.105 0.895,2 2,2 1.105,0 2,-0.895 2,-2 0,-0.0154 -0.0036,-0.02961 -0.0039,-0.04492 L 28,27.472656 c 1.887,-1.352 3.355,-1.671969 5.5,-1.167968 l 0,4.765624 C 33.339212,31.028672 33.173852,31 33,31 c -1.102,0 -2,0.895 -2,2 0,1.105 0.898,2 2,2 1.084889,0 1.962378,-0.864245 1.994141,-1.941406 6.8e-4,1.84e-4 0.0013,-1.84e-4 0.002,0 l 0,-0.01953 C 34.996356,33.025718 35,33.013408 35,33 35,32.98659 34.9964,32.97428 34.9961,32.96094 l 0,-9.785157 c -0.95125,-0.086 -1.789375,-0.150203 -2.554688,-0.169922 z"
+         id="path3544" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#4755d8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 27,33 c 0,1.105 -0.895,2 -2,2 -1.105,0 -2,-0.895 -2,-2 0,-1.105 0.895,-2 2,-2 1.105,0 2,0.895 2,2 m 0,0"
+         id="path175" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#4755d8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 27,26.473 c 1.887,-1.352 3.355,-1.672 5.5,-1.168 l 0,5.03 c -0.105,0.199 -0.531,1.176 1.496,1.723 l 0,-9.883 c -3.805,-0.344 -5.813,-0.328 -8.5,1.41 l 0,7.914 c 0.684,-1.023 -2.789,2.422 1.5,1.457 M 27,26.472"
+         id="path173" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#4755d8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         d="m 34,32 c 0,1.105 -0.895,2 -2,2 -1.102,0 -2,-0.895 -2,-2 0,-1.105 0.898,-2 2,-2 1.105,0 2,0.895 2,2 m 0,0"
+         id="path177" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for KAudioCreator. Fixes #1964
![kaudiocreator](https://cloud.githubusercontent.com/assets/7050624/7178011/ce1d742c-e42b-11e4-9938-f5f65d8cf9d4.png)
