### PR TITLE
Icon for Zanshin

### DIFF
--- a/Numix-Circle/48x48/apps/zanshin.svg
+++ b/Numix-Circle/48x48/apps/zanshin.svg
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg83"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="zanshin0.svg">
+  <metadata
+     id="metadata170">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview168"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="16.899306"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg83" />
+  <defs
+     id="defs85">
+    <linearGradient
+       id="linearGradient3764"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#575757"
+         stop-opacity="1"
+         id="stop88" />
+      <stop
+         offset="1"
+         stop-color="#616161"
+         stop-opacity="1"
+         id="stop90" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-741860139">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g271">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path273" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-749234531">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g276">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path278" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g102">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path104" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path106" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path108" />
+  </g>
+  <g
+     id="g110">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path112" />
+  </g>
+  <g
+     id="g114" />
+  <g
+     id="g164">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path166" />
+  </g>
+  <g
+     transform="translate(-0.004,-0.01)"
+     id="g294">
+    <g
+       clip-path="url(#clipPath-741860139)"
+       id="g296">
+      <g
+         transform="translate(1,1)"
+         id="g298">
+        <g
+           style="opacity:0.1"
+           id="g300">
+          <!-- color: #eeeeee -->
+          <g
+             id="g302">
+            <path
+               style="fill:#000000;fill-opacity:0.71399997;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 15.949,13.03 16.11,0 c 0.523,0 0.945,0.434 0.945,0.973 l 0,20.03 c 0,0.539 -0.422,0.977 -0.945,0.977 l -16.11,0 c -0.523,0 -0.945,-0.438 -0.945,-0.977 l 0,-20.03 c 0,-0.539 0.422,-0.973 0.945,-0.973 m 0,0"
+               id="path304" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 17,15 14,0 0,13 -5,5 -9,0.027 m 0,-18.03"
+               id="path306" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19,13 10,0 0,3 -10,0 m 0,-3"
+               id="path308" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 26,28 0,5 5,-5 m -5,0"
+               id="path310" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 19.15,24.566 2.211,2.926 c 0.66,0.672 1.406,0.672 1.66,0 1.066,-2.484 3.934,-7.109 5.824,-8.469 0.504,-0.547 -0.324,-1.293 -0.961,-0.93 -1.367,0.648 -5.305,6.242 -5.813,7.824 l -1.672,-2.309 c -0.613,-0.887 -1.82,0.105 -1.25,0.953 m 0,0.004"
+               id="path312" />
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 22,13 0,-1 4,0 0,1 m -4,0"
+               id="path314" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     transform="translate(-0.004,-0.01)"
+     id="g316">
+    <g
+       clip-path="url(#clipPath-749234531)"
+       id="g318">
+      <!-- color: #eeeeee -->
+      <g
+         id="g320">
+        <path
+           inkscape:connector-curvature="0"
+           d="m 15.949,13.03 16.11,0 c 0.523,0 0.945,0.434 0.945,0.973 l 0,20.03 c 0,0.539 -0.422,0.977 -0.945,0.977 l -16.11,0 c -0.523,0 -0.945,-0.438 -0.945,-0.977 l 0,-20.03 c 0,-0.539 0.422,-0.973 0.945,-0.973 m 0,0"
+           id="path322"
+           style="fill:#b19e7b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           style="fill:#ececec;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 17,15 14,0 0,13 -5,5 -9,0.027 m 0,-18.03"
+           id="path324" />
+        <path
+           style="fill:#a8a9a8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 19,13 10,0 0,3 -10,0 m 0,-3"
+           id="path326" />
+        <path
+           style="fill:#b4b4b4;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 26,28 0,5 5,-5 m -5,0"
+           id="path328" />
+        <path
+           style="fill:#535353;fill-opacity:1;fill-rule:evenodd;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 19.15,24.566 2.211,2.926 c 0.66,0.672 1.406,0.672 1.66,0 1.066,-2.484 3.934,-7.109 5.824,-8.469 0.504,-0.547 -0.324,-1.293 -0.961,-0.93 -1.367,0.648 -5.305,6.242 -5.813,7.824 l -1.672,-2.309 c -0.613,-0.887 -1.82,0.105 -1.25,0.953 m 0,0.004"
+           id="path330" />
+        <path
+           style="fill:#a8a9a8;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 22,13 0,-1 4,0 0,1 m -4,0"
+           id="path332" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Zanshin. Fixes #1966
![zanshin-icon](https://cloud.githubusercontent.com/assets/7050624/7178048/1509fa4a-e42c-11e4-9f66-31d4640291c0.png)
