### PR TITLE
Fixes for Opensong, Musique, GTG

### DIFF
--- a/Numix-Circle/48x48/apps/gtg.svg
+++ b/Numix-Circle/48x48/apps/gtg.svg
@@ -1,1 +1,237 @@
-<svg viewBox="0 0 48 48"><defs><linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)"><stop stop-color="#e4e4e4" stop-opacity="1"/><stop offset="1" stop-color="#eee" stop-opacity="1"/></linearGradient><clipPath id="clipPath-741860139"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath><clipPath id="clipPath-749234531"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath></defs><g><path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" opacity="0.05"/><path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" opacity="0.1"/><path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" opacity="0.2"/></g><g><path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" fill="url(#linearGradient3764)" fill-opacity="1"/></g><g/><g><g clip-path="url(#clipPath-741860139)"><g transform="translate(1,1)"><g opacity="0.1"><!-- color: #eeeeee --><g><path d="m 15.949 13.03 l 16.11 0 c 0.523 0 0.945 0.434 0.945 0.973 l 0 20.03 c 0 0.539 -0.422 0.977 -0.945 0.977 l -16.11 0 c -0.523 0 -0.945 -0.438 -0.945 -0.977 l 0 -20.03 c 0 -0.539 0.422 -0.973 0.945 -0.973 m 0 0" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="0.714"/><path d="m 17 15 l 14 0 l 0 13 l -5 5 l -9 0.027 m 0 -18.03" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 19 13 l 10 0 l 0 3 l -10 0 m 0 -3" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 26 28 l 0 5 l 5 -5 m -5 0" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 19.15 24.566 l 2.211 2.926 c 0.66 0.672 1.406 0.672 1.66 0 c 1.066 -2.484 3.934 -7.109 5.824 -8.469 c 0.504 -0.547 -0.324 -1.293 -0.961 -0.93 c -1.367 0.648 -5.305 6.242 -5.813 7.824 l -1.672 -2.309 c -0.613 -0.887 -1.82 0.105 -1.25 0.953 m 0 0.004" fill="#000" stroke="none" fill-rule="evenodd" fill-opacity="1"/><path d="m 22 13 l 0 -1 l 4 0 l 0 1 m -4 0" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/></g></g></g></g></g><g><g clip-path="url(#clipPath-749234531)"><!-- color: #eeeeee --><g><path d="m 15.949 13.03 l 16.11 0 c 0.523 0 0.945 0.434 0.945 0.973 l 0 20.03 c 0 0.539 -0.422 0.977 -0.945 0.977 l -16.11 0 c -0.523 0 -0.945 -0.438 -0.945 -0.977 l 0 -20.03 c 0 -0.539 0.422 -0.973 0.945 -0.973 m 0 0" fill="#95620a" stroke="none" fill-rule="nonzero" fill-opacity="0.714"/><path d="m 17 15 l 14 0 l 0 13 l -5 5 l -9 0.027 m 0 -18.03" fill="#ececec" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 19 13 l 10 0 l 0 3 l -10 0 m 0 -3" fill="#535453" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 26 28 l 0 5 l 5 -5 m -5 0" fill="#a3a3a3" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 19.15 24.566 l 2.211 2.926 c 0.66 0.672 1.406 0.672 1.66 0 c 1.066 -2.484 3.934 -7.109 5.824 -8.469 c 0.504 -0.547 -0.324 -1.293 -0.961 -0.93 c -1.367 0.648 -5.305 6.242 -5.813 7.824 l -1.672 -2.309 c -0.613 -0.887 -1.82 0.105 -1.25 0.953 m 0 0.004" fill="#535353" stroke="none" fill-rule="evenodd" fill-opacity="1"/><path d="m 22 13 l 0 -1 l 4 0 l 0 1 m -4 0" fill="#535453" stroke="none" fill-rule="nonzero" fill-opacity="1"/></g></g></g><g><path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" opacity="0.1"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg261"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="gtg-neu.svg">
+  <metadata
+     id="metadata340">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview338"
+     showgrid="true"
+     inkscape:zoom="19.666667"
+     inkscape:cx="15.483051"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg261" />
+  <defs
+     id="defs263">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#e4e4e4"
+         stop-opacity="1"
+         id="stop266" />
+      <stop
+         offset="1"
+         stop-color="#eee"
+         stop-opacity="1"
+         id="stop268" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-741860139">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g271">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path273" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-749234531">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g276">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path278" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g280">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path282" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path284" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path286" />
+  </g>
+  <g
+     id="g288">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path290" />
+  </g>
+  <g
+     id="g292" />
+  <g
+     id="g294">
+    <g
+       clip-path="url(#clipPath-741860139)"
+       id="g296">
+      <g
+         transform="translate(1,1)"
+         id="g298">
+        <g
+           opacity="0.1"
+           id="g300">
+          <!-- color: #eeeeee -->
+          <g
+             id="g302">
+            <path
+               d="m 15.949 13.03 l 16.11 0 c 0.523 0 0.945 0.434 0.945 0.973 l 0 20.03 c 0 0.539 -0.422 0.977 -0.945 0.977 l -16.11 0 c -0.523 0 -0.945 -0.438 -0.945 -0.977 l 0 -20.03 c 0 -0.539 0.422 -0.973 0.945 -0.973 m 0 0"
+               fill="#000"
+               stroke="none"
+               fill-rule="nonzero"
+               fill-opacity="0.714"
+               id="path304" />
+            <path
+               d="m 17 15 l 14 0 l 0 13 l -5 5 l -9 0.027 m 0 -18.03"
+               fill="#000"
+               stroke="none"
+               fill-rule="nonzero"
+               fill-opacity="1"
+               id="path306" />
+            <path
+               d="m 19 13 l 10 0 l 0 3 l -10 0 m 0 -3"
+               fill="#000"
+               stroke="none"
+               fill-rule="nonzero"
+               fill-opacity="1"
+               id="path308" />
+            <path
+               d="m 26 28 l 0 5 l 5 -5 m -5 0"
+               fill="#000"
+               stroke="none"
+               fill-rule="nonzero"
+               fill-opacity="1"
+               id="path310" />
+            <path
+               d="m 19.15 24.566 l 2.211 2.926 c 0.66 0.672 1.406 0.672 1.66 0 c 1.066 -2.484 3.934 -7.109 5.824 -8.469 c 0.504 -0.547 -0.324 -1.293 -0.961 -0.93 c -1.367 0.648 -5.305 6.242 -5.813 7.824 l -1.672 -2.309 c -0.613 -0.887 -1.82 0.105 -1.25 0.953 m 0 0.004"
+               fill="#000"
+               stroke="none"
+               fill-rule="evenodd"
+               fill-opacity="1"
+               id="path312" />
+            <path
+               d="m 22 13 l 0 -1 l 4 0 l 0 1 m -4 0"
+               fill="#000"
+               stroke="none"
+               fill-rule="nonzero"
+               fill-opacity="1"
+               id="path314" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g316">
+    <g
+       clip-path="url(#clipPath-749234531)"
+       id="g318">
+      <!-- color: #eeeeee -->
+      <g
+         id="g320">
+        <path
+           d="m 15.949 13.03 l 16.11 0 c 0.523 0 0.945 0.434 0.945 0.973 l 0 20.03 c 0 0.539 -0.422 0.977 -0.945 0.977 l -16.11 0 c -0.523 0 -0.945 -0.438 -0.945 -0.977 l 0 -20.03 c 0 -0.539 0.422 -0.973 0.945 -0.973 m 0 0"
+           id="path322"
+           stroke="none"
+           fill-rule="nonzero"
+           fill-opacity="0.714"
+           fill="#95620a"
+           style="fill:#a88445;fill-opacity:1" />
+        <path
+           d="m 17 15 l 14 0 l 0 13 l -5 5 l -9 0.027 m 0 -18.03"
+           id="path324"
+           stroke="none"
+           fill-rule="nonzero"
+           fill-opacity="1"
+           fill="#ececec" />
+        <path
+           d="m 19 13 l 10 0 l 0 3 l -10 0 m 0 -3"
+           id="path326"
+           stroke="none"
+           fill-rule="nonzero"
+           fill-opacity="1"
+           fill="#535453" />
+        <path
+           d="m 26 28 l 0 5 l 5 -5 m -5 0"
+           id="path328"
+           stroke="none"
+           fill-rule="nonzero"
+           fill-opacity="1"
+           fill="#a3a3a3" />
+        <path
+           d="m 19.15 24.566 l 2.211 2.926 c 0.66 0.672 1.406 0.672 1.66 0 c 1.066 -2.484 3.934 -7.109 5.824 -8.469 c 0.504 -0.547 -0.324 -1.293 -0.961 -0.93 c -1.367 0.648 -5.305 6.242 -5.813 7.824 l -1.672 -2.309 c -0.613 -0.887 -1.82 0.105 -1.25 0.953 m 0 0.004"
+           id="path330"
+           stroke="none"
+           fill-rule="evenodd"
+           fill-opacity="1"
+           fill="#535353" />
+        <path
+           d="m 22 13 l 0 -1 l 4 0 l 0 1 m -4 0"
+           id="path332"
+           stroke="none"
+           fill-rule="nonzero"
+           fill-opacity="1"
+           fill="#535453" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g334">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path336" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/musique.svg
+++ b/Numix-Circle/48x48/apps/musique.svg
@@ -1,1 +1,188 @@
-<svg viewBox="0 0 48 48"><defs><linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)"><stop stop-color="#3d3d3d" stop-opacity="1"/><stop offset="1" stop-color="#474747" stop-opacity="1"/></linearGradient><clipPath id="clipPath-946026794"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath><clipPath id="clipPath-951237116"><g transform="translate(0,-1004.3622)"><path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" fill="#1890d0"/></g></clipPath></defs><g><path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" opacity="0.05"/><path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" opacity="0.1"/><path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" opacity="0.2"/></g><g><path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" fill="url(#linearGradient3764)" fill-opacity="1"/></g><g/><g><g clip-path="url(#clipPath-946026794)"><g transform="translate(1,1)"><g opacity="0.1"><!-- color: #474747 --><g><path d="m 34.938 11 l -2.477 0.563 l -14.496 3.359 l -1.559 0.367 l 0 16.531 l 4.04 0 l 0 -13.332 l 10.445 -2.41 l 0 14.207 l 4.051 0 m 0 -19.285" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 20.08 30.715 c 1 1.797 0.102 4.285 -2.02 5.559 c -2.121 1.273 -4.652 0.848 -5.652 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.27 4.645 -0.848 5.645 0.953 m 0 0" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 34.594 29.26 c 1 1.797 0.094 4.285 -2.027 5.559 c -2.121 1.273 -4.652 0.848 -5.656 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.273 4.656 -0.844 5.656 0.953 m 0 0" fill="#000" stroke="none" fill-rule="nonzero" fill-opacity="1"/></g></g></g></g></g><g><g clip-path="url(#clipPath-951237116)"><!-- color: #474747 --><g><path d="m 34.938 11 l -2.477 0.563 l -14.496 3.359 l -1.559 0.367 l 0 16.531 l 4.04 0 l 0 -13.332 l 10.445 -2.41 l 0 14.207 l 4.051 0 m 0 -19.285" fill="#00cfff" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 20.08 30.715 c 1 1.797 0.102 4.285 -2.02 5.559 c -2.121 1.273 -4.652 0.848 -5.652 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.27 4.645 -0.848 5.645 0.953 m 0 0" fill="#00cfff" stroke="none" fill-rule="nonzero" fill-opacity="1"/><path d="m 34.594 29.26 c 1 1.797 0.094 4.285 -2.027 5.559 c -2.121 1.273 -4.652 0.848 -5.656 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.273 4.656 -0.844 5.656 0.953 m 0 0" fill="#00cfff" stroke="none" fill-rule="nonzero" fill-opacity="1"/></g></g></g><g><path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" opacity="0.1"/></g></svg>
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="musique.svg">
+  <metadata
+     id="metadata69">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview67"
+     showgrid="false"
+     inkscape:zoom="19.666667"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3397" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#3d3d3d"
+         stop-opacity="1"
+         id="stop7" />
+      <stop
+         offset="1"
+         stop-color="#474747"
+         stop-opacity="1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-946026794">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-951237116">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g35">
+    <g
+       clip-path="url(#clipPath-946026794)"
+       id="g37">
+      <g
+         transform="translate(1,1)"
+         id="g39">
+        <g
+           opacity="0.1"
+           id="g41">
+          <!-- color: #474747 -->
+          <g
+             id="g43">
+            <path
+               d="M 34.998,11 C 28.817483,12.415587 22.171871,13.836096 16,15.289 l 0,16.531 4,0 0,-13.332 11,-2.41 0,14.922 4.002,0"
+               id="path45"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="cccccccc" />
+            <path
+               d="m 19.566902,30.715 c 1.060397,1.797 0.10816,4.285 -2.142003,5.559 -2.249103,1.273 -4.932969,0.848 -5.993366,-0.949 -1.060397,-1.797 -0.09968,-4.289 2.149426,-5.563 2.249102,-1.27 4.925545,-0.848 5.985943,0.953 m 0,0"
+               id="path47"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+            <path
+               d="m 34.568952,29.26 c 1.059209,1.797 0.09957,4.285 -2.147016,5.559 -2.246582,1.273 -4.92744,0.848 -5.990886,-0.949 -1.059209,-1.797 -0.09957,-4.289 2.147017,-5.563 2.246582,-1.273 4.931676,-0.844 5.990885,0.953 m 0,0"
+               id="path49"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+          </g>
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     id="g51">
+    <g
+       clip-path="url(#clipPath-951237116)"
+       id="g53">
+      <!-- color: #474747 -->
+      <g
+         id="g55">
+        <path
+           d="M 34.998,11 C 28.817483,12.415587 22.171871,13.836096 16,15.289 l 0,16.911 4,0 0,-13.712 11,-2.41 0,14.922 4.002,0"
+           id="path57"
+           inkscape:connector-curvature="0"
+           style="fill:#00cfff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           sodipodi:nodetypes="cccccccc" />
+        <path
+           d="m 19.566902,30.715 c 1.060397,1.797 0.10816,4.285 -2.142003,5.559 -2.249103,1.273 -4.932969,0.848 -5.993366,-0.949 -1.060397,-1.797 -0.09968,-4.289 2.149426,-5.563 2.249102,-1.27 4.925545,-0.848 5.985943,0.953 m 0,0"
+           id="path59"
+           inkscape:connector-curvature="0"
+           style="fill:#00cfff;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+        <path
+           d="m 34.568952,29.26 c 1.059209,1.797 0.09957,4.285 -2.147016,5.559 -2.246582,1.273 -4.92744,0.848 -5.990886,-0.949 -1.059209,-1.797 -0.09957,-4.289 2.147017,-5.563 2.246582,-1.273 4.931676,-0.844 5.990885,0.953 m 0,0"
+           id="path61"
+           inkscape:connector-curvature="0"
+           style="fill:#00cfff;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g63">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path65" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/opensong.svg
+++ b/Numix-Circle/48x48/apps/opensong.svg
@@ -11,7 +11,7 @@
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
+   inkscape:version="0.91 r13725"
    width="100%"
    height="100%"
    sodipodi:docname="opensong.svg">
@@ -23,6 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -35,17 +36,21 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1280"
-     inkscape:window-height="998"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
      id="namedview67"
      showgrid="false"
-     inkscape:zoom="2.4583333"
-     inkscape:cx="53.851726"
-     inkscape:cy="-41.318175"
+     inkscape:zoom="8"
+     inkscape:cx="26.457249"
+     inkscape:cy="18.883712"
      inkscape:window-x="0"
-     inkscape:window-y="0"
+     inkscape:window-y="28"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3436" />
+  </sodipodi:namedview>
   <defs
      id="defs4">
     <linearGradient
@@ -58,22 +63,6 @@
          style="stop-color:#903292;stop-opacity:1;"
          offset="1"
          id="stop3832" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3764"
-       x1="1"
-       x2="47"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-      <stop
-         stop-color="#3d3d3d"
-         stop-opacity="1"
-         id="stop7" />
-      <stop
-         offset="1"
-         stop-color="#474747"
-         stop-opacity="1"
-         id="stop9" />
     </linearGradient>
     <clipPath
        id="clipPath-946026794">
@@ -147,26 +136,21 @@
           <g
              id="g43">
             <path
-               d="m 34.938 11 l -2.477 0.563 l -14.496 3.359 l -1.559 0.367 l 0 16.531 l 4.04 0 l 0 -13.332 l 10.445 -2.41 l 0 14.207 l 4.051 0 m 0 -19.285"
-               fill="#000"
-               stroke="none"
-               fill-rule="nonzero"
-               fill-opacity="1"
-               id="path45" />
+               d="M 34.998,11 C 28.817483,12.415587 22.171871,13.836096 16,15.289 l 0,16.911 4,0 0,-13.712 11,-2.41 0,14.922 4.002,0"
+               id="path45"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               sodipodi:nodetypes="cccccccc" />
             <path
-               d="m 20.08 30.715 c 1 1.797 0.102 4.285 -2.02 5.559 c -2.121 1.273 -4.652 0.848 -5.652 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.27 4.645 -0.848 5.645 0.953 m 0 0"
-               fill="#000"
-               stroke="none"
-               fill-rule="nonzero"
-               fill-opacity="1"
-               id="path47" />
+               d="m 19.566902,30.715 c 1.060397,1.797 0.10816,4.285 -2.142003,5.559 -2.249103,1.273 -4.932969,0.848 -5.993366,-0.949 -1.060397,-1.797 -0.09968,-4.289 2.149426,-5.563 2.249102,-1.27 4.925545,-0.848 5.985943,0.953 m 0,0"
+               id="path47"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
             <path
-               d="m 34.594 29.26 c 1 1.797 0.094 4.285 -2.027 5.559 c -2.121 1.273 -4.652 0.848 -5.656 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.273 4.656 -0.844 5.656 0.953 m 0 0"
-               fill="#000"
-               stroke="none"
-               fill-rule="nonzero"
-               fill-opacity="1"
-               id="path49" />
+               d="m 34.568952,29.26 c 1.059209,1.797 0.09957,4.285 -2.147016,5.559 -2.246582,1.273 -4.92744,0.848 -5.990886,-0.949 -1.059209,-1.797 -0.09957,-4.289 2.147017,-5.563 2.246582,-1.273 4.931676,-0.844 5.990885,0.953 m 0,0"
+               id="path49"
+               inkscape:connector-curvature="0"
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none" />
           </g>
         </g>
       </g>
@@ -184,29 +168,21 @@
          id="g55"
          style="fill:#fed7ff;fill-opacity:1">
         <path
-           d="m 34.938 11 l -2.477 0.563 l -14.496 3.359 l -1.559 0.367 l 0 16.531 l 4.04 0 l 0 -13.332 l 10.445 -2.41 l 0 14.207 l 4.051 0 m 0 -19.285"
-           fill="#00cfff"
-           stroke="none"
-           fill-rule="nonzero"
-           fill-opacity="1"
+           d="M 34.998,11 C 28.817483,12.415587 22.171871,13.836096 16,15.289 l 0,16.911 4,0 0,-13.712 11,-2.41 0,14.922 4.002,0"
            id="path57"
-           style="fill:#fed7ff;fill-opacity:1" />
+           style="fill:#fed7ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
         <path
-           d="m 20.08 30.715 c 1 1.797 0.102 4.285 -2.02 5.559 c -2.121 1.273 -4.652 0.848 -5.652 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.27 4.645 -0.848 5.645 0.953 m 0 0"
-           fill="#00cfff"
-           stroke="none"
-           fill-rule="nonzero"
-           fill-opacity="1"
+           d="m 19.566902,30.715 c 1.060397,1.797 0.10816,4.285 -2.142003,5.559 -2.249103,1.273 -4.932969,0.848 -5.993366,-0.949 -1.060397,-1.797 -0.09968,-4.289 2.149426,-5.563 2.249102,-1.27 4.925545,-0.848 5.985943,0.953 m 0,0"
            id="path59"
-           style="fill:#fed7ff;fill-opacity:1" />
+           style="fill:#fed7ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
         <path
-           d="m 34.594 29.26 c 1 1.797 0.094 4.285 -2.027 5.559 c -2.121 1.273 -4.652 0.848 -5.656 -0.949 c -1 -1.797 -0.094 -4.289 2.027 -5.563 c 2.121 -1.273 4.656 -0.844 5.656 0.953 m 0 0"
-           fill="#00cfff"
-           stroke="none"
-           fill-rule="nonzero"
-           fill-opacity="1"
+           d="m 34.568952,29.26 c 1.059209,1.797 0.09957,4.285 -2.147016,5.559 -2.246582,1.273 -4.92744,0.848 -5.990886,-0.949 -1.059209,-1.797 -0.09957,-4.289 2.147017,-5.563 2.246582,-1.273 4.931676,-0.844 5.990885,0.953 m 0,0"
            id="path61"
-           style="fill:#fed7ff;fill-opacity:1" />
+           style="fill:#fed7ff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+           inkscape:connector-curvature="0" />
       </g>
     </g>
   </g>


### PR DESCRIPTION
The icons for Opensong and Musique (same design, recoloured)had their symbols misaligned.
Before:
![opensong-old](https://cloud.githubusercontent.com/assets/7050624/7178207/5e4d22da-e42d-11e4-8816-0b53c57c33aa.png)
After:
![opensong](https://cloud.githubusercontent.com/assets/7050624/7178214/68259f1c-e42d-11e4-82a3-f49f91ebb070.png)

The GTG icon's symbols used a transparent color. Replaced it by the equivalent A255 colour.
![gtg-old](https://cloud.githubusercontent.com/assets/7050624/7178234/869073aa-e42d-11e4-86d0-e3f70d074bd6.png)

