### PR TITLE
Icon for gpsprune

### DIFF
--- a/Numix-Circle/48x48/apps/gpsprune.svg
+++ b/Numix-Circle/48x48/apps/gpsprune.svg
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg113"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="gpsprune0.svg">
+  <metadata
+     id="metadata180">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview178"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="12.895761"
+     inkscape:cy="22.495716"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg113">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3508" />
+  </sodipodi:namedview>
+  <defs
+     id="defs115">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#cfbcad"
+         stop-opacity="1"
+         id="stop118" />
+      <stop
+         offset="1"
+         stop-color="#d6c6b9"
+         stop-opacity="1"
+         id="stop120" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3837"
+       id="linearGradient3843"
+       x1="23"
+       y1="13"
+       x2="23"
+       y2="31"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.9587455,0,0,0.97514518,0.98996259,0.60596513)" />
+    <linearGradient
+       id="linearGradient3837">
+      <stop
+         style="stop-color:#5cb634;stop-opacity:1"
+         offset="0"
+         id="stop3839" />
+      <stop
+         style="stop-color:#57ac32;stop-opacity:1"
+         offset="1"
+         id="stop3841-9" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g132">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path134" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path136" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path138" />
+  </g>
+  <g
+     id="g140">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path142" />
+  </g>
+  <g
+     id="g144" />
+  <g
+     id="g174">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path176" />
+  </g>
+  <g
+     transform="scale(3.543307,3.543307)"
+     id="g5460">
+    <rect
+       id="rect3955"
+       style="fill:#000000;fill-opacity:0.09803922"
+       rx="0.57921606"
+       ry="0.55182749"
+       height="7.3377781"
+       width="5.6444445"
+       y="3.3866665"
+       x="4.2333336" />
+    <g
+       id="g4636"
+       transform="scale(0.28222223,0.28222223)">
+      <g
+         id="g4624">
+        <rect
+           x="14"
+           y="11"
+           width="20"
+           height="26"
+           ry="1.9552943"
+           rx="2.0523403"
+           style="fill:#3c3c3c;fill-opacity:1"
+           id="rect4717" />
+        <rect
+           x="15"
+           y="12"
+           width="18"
+           height="20"
+           ry="1.9953333"
+           rx="2.072885"
+           style="fill:#787878;fill-opacity:1"
+           id="rect4727" />
+        <circle
+           r="48.680904"
+           cy="860.01324"
+           cx="-194.72362"
+           transform="matrix(0.0308129,0,0,0.0308129,36.5,8.000495)"
+           style="opacity:0.63555998;fill:#787878;fill-opacity:1"
+           id="path5148" />
+        <circle
+           r="48.680904"
+           cy="860.01324"
+           cx="-194.72362"
+           transform="matrix(0.02054194,0,0,0.02054194,34.500001,16.833659)"
+           style="opacity:0.63555998;fill:#e91111;fill-opacity:1"
+           id="path5152" />
+        <g
+           id="g4619">
+          <rect
+             id="rect4739"
+             style="fill:url(#linearGradient3843);fill-opacity:1"
+             rx="1.967672"
+             ry="1.9066957"
+             height="18"
+             width="16"
+             y="13"
+             x="16" />
+          <path
+             sodipodi:nodetypes="ccccc"
+             style="fill:#000000;fill-opacity:0.09803922"
+             id="path3865"
+             d="m 32,22.5 -16,4 0,2 16,-4 z"
+             inkscape:connector-curvature="0" />
+          <path
+             inkscape:connector-curvature="0"
+             d="m 32,22 -16,4 0,2 16,-4 z"
+             id="path56"
+             style="fill:#ffe68e;fill-opacity:1"
+             sodipodi:nodetypes="ccccc" />
+        </g>
+      </g>
+      <g
+         id="g4614">
+        <path
+           style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none"
+           inkscape:connector-curvature="0"
+           d="m 24.507753,25.5 c -0.221136,-1.12448 -0.613664,-2.060274 -1.088932,-2.926393 -0.352142,-0.641834 -0.759938,-1.23586 -1.137198,-1.859384 -0.125097,-0.208519 -0.234926,-0.427211 -0.354113,-0.643868 -0.242313,-0.431279 -0.438823,-0.931726 -0.427003,-1.581188 0.01132,-0.63573 0.1906,-1.144314 0.448181,-1.561353 0.421093,-0.683537 1.129318,-1.245523 2.079856,-1.392503 0.775205,-0.121043 1.504607,0.08341 2.020262,0.39517 0.421093,0.252257 0.74861,0.591991 0.996341,0.993264 0.259551,0.417039 0.438823,0.909857 0.454091,1.553725 0.0079,0.329562 -0.0463,0.63573 -0.119186,0.887987 -0.07486,0.256327 -0.194541,0.470949 -0.301907,0.699304 -0.207838,0.447045 -0.469359,0.856456 -0.73285,1.265357 -0.781116,1.219585 -1.515935,2.465616 -1.83705,4.169882 m 0,0"
+           id="path3863" />
+        <path
+           id="path60-4"
+           d="m 24.007753,25 c -0.221136,-1.12448 -0.613664,-2.060274 -1.088932,-2.926393 -0.352142,-0.641834 -0.759938,-1.23586 -1.137198,-1.859384 -0.125097,-0.208519 -0.234926,-0.427211 -0.354113,-0.643868 -0.242313,-0.431279 -0.438823,-0.931726 -0.427003,-1.581188 0.01132,-0.63573 0.1906,-1.144314 0.448181,-1.561353 0.421093,-0.683537 1.129318,-1.245523 2.079856,-1.392503 0.775205,-0.121043 1.504607,0.08341 2.020262,0.39517 0.421093,0.252257 0.74861,0.591991 0.996341,0.993264 0.259551,0.417039 0.438823,0.909857 0.454091,1.553725 0.0079,0.329562 -0.0463,0.63573 -0.119186,0.887987 -0.07486,0.256327 -0.194541,0.470949 -0.301907,0.699304 -0.207838,0.447045 -0.469359,0.856456 -0.73285,1.265357 C 25.064179,22.049703 24.32936,23.295734 24.008245,25 m 0,0"
+           inkscape:connector-curvature="0"
+           style="fill:#f3533d;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+        <path
+           id="path62-0"
+           d="m 25.4,18.1 c 0,0.773332 -0.625805,1.4 -1.398977,1.4 C 23.227339,19.5 22.6,18.87282 22.6,18.1 c 0,-0.773333 0.62785,-1.4 1.401023,-1.4 0.773685,0 1.398977,0.62718 1.398977,1.4 m 0,0"
+           inkscape:connector-curvature="0"
+           style="fill:#c12f20;fill-opacity:1;fill-rule:evenodd;stroke:none" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Icon for gpsprune. Fixes #1977
![gpsprune](https://cloud.githubusercontent.com/assets/7050624/7187459/d89eb0d8-e470-11e4-9713-cdeef25ea196.png)
