### PR TITLE
Symlink for Klipper

### DIFF
--- a/Numix-Circle/48x48/apps/klipper.svg
+++ b/Numix-Circle/48x48/apps/klipper.svg
@@ -1,0 +1,1 @@
+diodon.svg


### PR DESCRIPTION
Symlink for Klipper. Fixes #1992
Symlink to *diodon.svg*