### PR TITLE
Icon for Umbrello

### DIFF
--- a/Numix-Circle/48x48/apps/umbrello.svg
+++ b/Numix-Circle/48x48/apps/umbrello.svg
@@ -1,0 +1,212 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="umbrello9i.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="16"
+     inkscape:cx="17.597334"
+     inkscape:cy="28.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#f0e8cc;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#f5efdb;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <path
+     style="fill:#000000;fill-opacity:0.09803922;stroke:none"
+     d="m 25,12 c -0.552285,0 -1,0.447714 -1,1 l -12,10 0,2 12.5,0 0,9 -0.5,0 0,3.5 c 0,0.277 0.223,0.5 0.5,0.5 l 1,0 c 0.277,0 0.5,-0.223 0.5,-0.5 l 0,-3.5 -0.5,0 0,-9 12.5,0 0,-2 -12,-10 c 0,-0.552286 -0.447715,-1 -1,-1 z"
+     id="rect4316"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sccccccssssccccccs" />
+  <g
+     id="g4339"
+     transform="translate(0,1)">
+    <rect
+       y="21"
+       x="27"
+       height="2"
+       width="6"
+       id="rect4289"
+       style="fill:#d8dee0;fill-opacity:1;stroke:none" />
+    <rect
+       y="18"
+       x="23.5"
+       height="15"
+       width="1"
+       id="rect4281"
+       style="fill:#7d7d7d;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="csssscc"
+       inkscape:connector-curvature="0"
+       id="rect4534"
+       d="m 25,32 0,3.5 c 0,0.277 -0.223,0.5 -0.5,0.5 l -1,0 C 23.223,36 23,35.777 23,35.5 L 23,32 Z"
+       style="fill:#424242;fill-opacity:1;stroke:none;stroke-width:0.03028834;stroke-dasharray:0.1817309, 0.18173090000000000" />
+    <circle
+       r="1"
+       cy="11"
+       cx="24"
+       id="path4236"
+       style="fill:#8c8c8c;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3349"
+       d="m 35,21 -22,0 10,-10 2,0 z"
+       style="fill:#e1e9eb;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <rect
+       style="fill:#d8dee0;fill-opacity:1;stroke:none"
+       id="rect4293"
+       width="6"
+       height="2"
+       x="15"
+       y="21" />
+    <path
+       style="fill:#3f839f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 27.5,21 -7,0 3.25,-10 0.5,0 z"
+       id="path4187"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#3f839f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 15.25,21 11,21 23,11 l 0.25,0 z"
+       id="path4189"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path4191"
+       d="M 32.75,21 37,21 25,11 24.75,11 Z"
+       style="fill:#3f839f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <rect
+       y="21"
+       x="32.75"
+       height="2"
+       width="4.25"
+       id="rect4287"
+       style="fill:#3d7389;fill-opacity:1;stroke:none" />
+    <rect
+       y="21"
+       x="20.5"
+       height="2"
+       width="7"
+       id="rect4291"
+       style="fill:#3d7389;fill-opacity:1;stroke:none" />
+    <rect
+       style="fill:#3d7389;fill-opacity:1;stroke:none"
+       id="rect4295"
+       width="4.25"
+       height="2"
+       x="11"
+       y="21" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/umbrello.svg
+++ b/Numix-Circle/48x48/apps/umbrello.svg
@@ -14,7 +14,7 @@
    inkscape:version="0.91 r13725"
    width="100%"
    height="100%"
-   sodipodi:docname="umbrello9i.svg">
+   sodipodi:docname="umbrello0.svg">
   <metadata
      id="metadata65">
     <rdf:RDF>
@@ -23,7 +23,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -40,9 +40,9 @@
      inkscape:window-height="713"
      id="namedview63"
      showgrid="false"
-     inkscape:zoom="16"
-     inkscape:cx="17.597334"
-     inkscape:cy="28.10541"
+     inkscape:zoom="1"
+     inkscape:cx="22.512928"
+     inkscape:cy="24.873177"
      inkscape:window-x="0"
      inkscape:window-y="28"
      inkscape:window-maximized="1"
@@ -130,13 +130,12 @@
   <g
      id="g4339"
      transform="translate(0,1)">
-    <rect
-       y="21"
-       x="27"
-       height="2"
-       width="6"
+    <path
+       style="fill:#d8dee0;fill-opacity:1;stroke:none"
+       d="m 27,20.5 6,0 0,2.5 -6,0 z"
        id="rect4289"
-       style="fill:#d8dee0;fill-opacity:1;stroke:none" />
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
     <rect
        y="18"
        x="23.5"
@@ -157,22 +156,33 @@
        id="path4236"
        style="fill:#8c8c8c;fill-opacity:1;stroke:none" />
     <path
+       style="fill:#d8dee0;fill-opacity:1;stroke:none"
+       d="m 15,21 c 2.032006,-0.416078 4.026824,-0.348709 6,0 l 0,2 -6,0 z"
+       id="rect4293"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path3349"
        d="m 35,21 -22,0 10,-10 2,0 z"
        style="fill:#e1e9eb;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <rect
-       style="fill:#d8dee0;fill-opacity:1;stroke:none"
-       id="rect4293"
-       width="6"
-       height="2"
-       x="15"
-       y="21" />
+    <path
+       style="fill:#3d7389;fill-opacity:1;stroke:none"
+       d="m 20.5,21 c 0.5,-1 6.5,-1 7,0 l 0,2 -7,0 z"
+       id="rect4291"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
     <path
        style="fill:#3f839f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        d="m 27.5,21 -7,0 3.25,-10 0.5,0 z"
        id="path4187"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#3d7389;fill-opacity:1;stroke:none"
+       d="m 11,21 4.25,-0.5 0,2.5 -4.25,0 z"
+       id="rect4295"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <path
@@ -182,31 +192,16 @@
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccc" />
     <path
+       style="fill:#3d7389;fill-opacity:1;stroke:none"
+       d="M 32.75,20.5 37,21 l 0,2 -4.25,0 z"
+       id="rect4287"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path4191"
        d="M 32.75,21 37,21 25,11 24.75,11 Z"
        style="fill:#3f839f;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
-    <rect
-       y="21"
-       x="32.75"
-       height="2"
-       width="4.25"
-       id="rect4287"
-       style="fill:#3d7389;fill-opacity:1;stroke:none" />
-    <rect
-       y="21"
-       x="20.5"
-       height="2"
-       width="7"
-       id="rect4291"
-       style="fill:#3d7389;fill-opacity:1;stroke:none" />
-    <rect
-       style="fill:#3d7389;fill-opacity:1;stroke:none"
-       id="rect4295"
-       width="4.25"
-       height="2"
-       x="11"
-       y="21" />
   </g>
 </svg>


### PR DESCRIPTION
Icon for Umbrello. Fixes #1994
Pushed:
![umbrello](https://cloud.githubusercontent.com/assets/7050624/7212604/2dada850-e56a-11e4-9a20-6d054a3ca727.png)
Alt:
![umbrello9a](https://cloud.githubusercontent.com/assets/7050624/7212606/33bb7876-e56a-11e4-9b3b-dec6e5ad55ed.png)
![umbrello9f](https://cloud.githubusercontent.com/assets/7050624/7214810/4c5df2c6-e5bc-11e4-9a6e-b98a00d855ec.png)

