### PR TITLE
Icon for Fraqtive. Fixes #2001

### DIFF
--- a/Numix-Circle/48x48/apps/fraqtive.svg
+++ b/Numix-Circle/48x48/apps/fraqtive.svg
@@ -1,0 +1,198 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   width="100%"
+   height="100%"
+   sodipodi:docname="fraqtive6.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview63"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="25.254345"
+     inkscape:cy="23.10541"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3847" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3839">
+      <stop
+         style="stop-color:#f4b36f;stop-opacity:1"
+         offset="0"
+         id="stop3841" />
+      <stop
+         style="stop-color:#f5bd83;stop-opacity:1"
+         offset="1"
+         id="stop3843" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3839"
+       id="linearGradient3845"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path31"
+       style="fill:url(#linearGradient3845);fill-opacity:1.0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     transform="scale(0.98451788,1.0157256)"
+     style="font-size:13.6171217px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Sans"
+     id="text3880" />
+  <g
+     transform="scale(1.0060815,0.99395525)"
+     style="font-size:19.87910461px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3023" />
+  <g
+     transform="matrix(1.0296335,0,0,0.97121938,-0.03651564,2.4817894e-7)"
+     style="font-size:18.98816872px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Montserrat;-inkscape-font-specification:Montserrat"
+     id="text3791" />
+  <path
+     style="fill:#000000;fill-opacity:0.09803922;stroke:none"
+     d="m 24.999999,10 c -0.690182,0 -1.249755,0.492248 -1.25,1.099609 5.72e-4,0.391067 0.237042,0.752464 0.621094,0.949219 -1.941027,0.28971 -3.369947,1.858542 -3.371094,3.701172 0.0022,1.463156 0.91189,2.791506 2.330078,3.402344 -2.363779,0.410444 -4.592609,1.660894 -6.152344,3.421875 C 17.096573,22.237584 16.795498,22.000275 16.449218,22 c -0.414214,0 -0.75,0.335786 -0.75,0.75 0,0.414214 0.335786,0.75 0.75,0.75 l 0.0038,0 C 15.58591,24.765402 15.053777,26.224917 15.007843,27.791016 14.72946,27.304477 14.188518,27.000619 13.599608,27 c -0.883503,2.02e-4 -1.599609,0.671716 -1.599609,1.5 0,0.828284 0.716106,1.499798 1.599609,1.5 0.618918,-8.74e-4 1.181789,-0.336314 1.445313,-0.861328 0.183815,2.131885 0.88832,3.740844 1.939453,4.861328 -0.546173,0.0085 -0.984442,0.45376 -0.984375,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 1.49e-4,-0.0477 -0.0031,-0.09535 -0.0098,-0.142578 C 19.124453,35.625718 20.503913,36 21.999999,36 c 1.067713,0 2.23811,-1.313538 3,-2.5 0.76189,1.186462 1.932287,2.5 3,2.5 1.496657,0 2.877255,-0.373684 4.011719,-1.142578 -0.0073,0.04719 -0.01122,0.09483 -0.01172,0.142578 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 6.7e-5,-0.54624 -0.438202,-0.991465 -0.984375,-1 1.051133,-1.120484 1.755638,-2.729443 1.939453,-4.861328 0.263524,0.525014 0.826395,0.860454 1.445313,0.861328 0.883503,-2.02e-4 1.599609,-0.671716 1.599609,-1.5 0,-0.828284 -0.716106,-1.499798 -1.599609,-1.5 -0.588463,2.32e-4 -1.129296,0.303278 -1.408203,0.789062 -0.04632,-1.565359 -0.578567,-3.024187 -1.445313,-4.289062 0.561366,-0.104871 0.574858,-0.485322 0.753906,-0.75 0,-0.414214 -0.335786,-0.75 -0.75,-0.75 -0.34628,2.75e-4 -0.647356,0.237584 -0.728515,0.574219 -1.559735,-1.760981 -3.788565,-3.011431 -6.152344,-3.421875 1.418188,-0.610838 2.327901,-1.939188 2.330078,-3.402344 -0.0025,-1.843074 -1.433199,-3.41124 -3.375,-3.699219 0.38624,-0.196236 0.624409,-0.5587 0.625,-0.951172 C 26.249753,10.492248 25.69018,10 24.999998,10 Z"
+     id="path4252"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="sccccccsscccsccccsccscsccsccccsccccccccccs" />
+  <g
+     id="g4239"
+     transform="translate(-3.5762787e-7,-0.9999997)"
+     style="fill:#4d4d4d;fill-opacity:1">
+    <path
+       sodipodi:nodetypes="zcscscz"
+       inkscape:connector-curvature="0"
+       id="path4144"
+       d="m 24,19 c -5,0 -10,4 -10.005859,9 0,5.503649 3.117677,8 7.005859,8 1.067713,0 2.23811,-1.313538 3,-2.5 0.76189,1.186462 1.932287,2.5 3,2.5 3.888182,0 7.005859,-2.496351 7.005859,-8 C 34,23 29,19 24,19 Z"
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none" />
+    <ellipse
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       id="path4157"
+       cx="450"
+       cy="363.98068"
+       rx="31.730768"
+       ry="28.980772"
+       transform="matrix(0.03939394,0,0,0.0379562,6.2727272,-2.715324)" />
+    <ellipse
+       ry="19.759617"
+       rx="19.038462"
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       id="path4162"
+       cx="232.96153"
+       cy="670.91345"
+       transform="matrix(0.03939394,0,0,0.0379562,6.2727272,-2.715324)" />
+    <ellipse
+       cy="670.91345"
+       cx="667.03845"
+       id="ellipse4231"
+       style="fill:#4d4d4d;fill-opacity:1;stroke:none"
+       rx="19.038462"
+       ry="19.759617"
+       transform="matrix(0.03939394,0,0,0.0379562,6.2727272,-2.715324)" />
+    <ellipse
+       ry="1.5"
+       rx="1.6"
+       cy="28.5"
+       cx="12.6"
+       id="path4207"
+       style="fill:#4d4d4d;fill-opacity:1" />
+    <ellipse
+       ry="1.5"
+       rx="1.6"
+       cy="28.5"
+       cx="35.400002"
+       id="path4209"
+       style="fill:#4d4d4d;fill-opacity:1" />
+    <circle
+       r="1"
+       cy="35"
+       cx="16"
+       id="path4211"
+       style="fill:#4d4d4d;fill-opacity:1" />
+    <circle
+       r="1"
+       cy="35"
+       cx="32"
+       id="path4229"
+       style="fill:#4d4d4d;fill-opacity:1" />
+    <ellipse
+       ry="3.75"
+       rx="4"
+       cy="15.75"
+       cx="24"
+       id="path4233"
+       style="fill:#4d4d4d;fill-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Fraqtive. Fixes #2001
![fraqtive](https://cloud.githubusercontent.com/assets/7050624/7216282/384d3330-e5fa-11e4-8ba1-14516480e07c.png)
