### PR TITLE
Icon for Buddi. Fixes #2022

### DIFF
--- a/Numix-Circle/48x48/apps/.directory
+++ b/Numix-Circle/48x48/apps/.directory
@@ -1,4 +1,0 @@
-[Dolphin]
-PreviewsShown=true
-Timestamp=2015,4,21,19,3,7
-Version=3

--- a/Numix-Circle/48x48/apps/.directory
+++ b/Numix-Circle/48x48/apps/.directory
@@ -1,0 +1,4 @@
+[Dolphin]
+PreviewsShown=true
+Timestamp=2015,4,21,19,3,7
+Version=3

--- a/Numix-Circle/48x48/apps/buddi.svg
+++ b/Numix-Circle/48x48/apps/buddi.svg
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg83"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="buddi3c1b.svg">
+  <metadata
+     id="metadata170">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview168"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="11.512886"
+     inkscape:cy="26.071068"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg83"
+     showguides="false" />
+  <defs
+     id="defs85">
+    <linearGradient
+       id="linearGradient3764"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         stop-color="#575757"
+         stop-opacity="1"
+         id="stop88" />
+      <stop
+         offset="1"
+         stop-color="#616161"
+         stop-opacity="1"
+         id="stop90" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g102">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path104" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path106" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path108" />
+  </g>
+  <g
+     id="g110">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path112" />
+  </g>
+  <g
+     id="g114" />
+  <g
+     id="g164">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path166" />
+  </g>
+  <circle
+     style="fill:#000000;fill-opacity:0.09803922;stroke:none"
+     id="path4164"
+     cx="25"
+     cy="25"
+     r="15" />
+  <g
+     id="g4287">
+    <g
+       id="g4204">
+      <path
+         id="path4160"
+         style="fill:#f3f29d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="m 18.869697,9.9046108 a 15,15 0 0 1 11.469577,0.5007722 15,15 0 0 1 7.756116,8.464315 L 24,24 Z"
+         sodipodi:type="arc"
+         sodipodi:start="4.3633231"
+         sodipodi:end="5.9341195"
+         sodipodi:ry="15"
+         sodipodi:rx="15"
+         sodipodi:cy="24"
+         sodipodi:cx="24" />
+      <path
+         style="fill:#c6d6e8;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path4162"
+         sodipodi:type="arc"
+         sodipodi:cx="24"
+         sodipodi:cy="24"
+         sodipodi:rx="15"
+         sodipodi:ry="15"
+         sodipodi:start="5.846853"
+         sodipodi:end="0.87266463"
+         d="M 37.594617,17.660726 A 15,15 0 0 1 33.641814,35.490667 L 24,24 Z" />
+      <path
+         style="fill:#f2a78a;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="path3358"
+         sodipodi:type="arc"
+         sodipodi:cx="24"
+         sodipodi:cy="24"
+         sodipodi:rx="15"
+         sodipodi:ry="15"
+         sodipodi:start="0.78539816"
+         sodipodi:end="4.5378561"
+         d="M 34.606602,34.606602 A 15,15 0 0 1 17.268012,37.40449 15,15 0 0 1 9.1583755,21.826022 15,15 0 0 1 21.395278,9.2278836 L 24,24 Z" />
+    </g>
+    <path
+       style="fill:#000000;fill-opacity:0.09803922;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 24,17 0,2.060547 C 23.157513,19.16981 22.481481,19.459375 21.978516,19.9375 21.326563,20.557255 21,21.442039 21,22.59375 c 0,0.919303 0.232892,1.649121 0.699219,2.191406 0.470854,0.542286 1.214367,0.937645 2.228515,1.185547 l 1.011719,0.255859 c 0.615733,0.154939 1.024781,0.331089 1.228516,0.527344 0.208262,0.196256 0.3125,0.474414 0.3125,0.835938 0,0.40284 -0.151739,0.712773 -0.455078,0.929687 -0.303339,0.216914 -0.740089,0.326172 -1.310547,0.326172 -0.561404,0 -1.145275,-0.09867 -1.751953,-0.294922 -0.602151,-0.20142 -1.227575,-0.498113 -1.875,-0.890625 l 0,2.517578 c 0.647425,0.273725 1.295934,0.479696 1.943359,0.619141 0.323713,0.06972 0.646169,0.123342 0.96875,0.158203 L 24,33 l 2,0 0,-2.066406 c 0.850366,-0.123185 1.521827,-0.405307 2.001953,-0.855469 C 28.667488,29.453206 29,28.502224 29,27.226562 29,26.255615 28.762491,25.50726 28.287109,24.980469 27.811727,24.453677 27.010147,24.060965 25.882812,23.802734 l -1.113281,-0.255859 c -0.529711,-0.123951 -0.897827,-0.270974 -1.101562,-0.441406 -0.199208,-0.175597 -0.296875,-0.418639 -0.296875,-0.728516 0,-0.41317 0.148454,-0.717807 0.447265,-0.914062 0.298812,-0.196256 0.759978,-0.294922 1.384766,-0.294922 0.470855,0 0.972242,0.07219 1.501953,0.216797 0.529711,0.144609 1.07203,0.358524 1.628906,0.642578 l 0,-2.447266 C 27.704669,19.388987 27.096381,19.24726 26.507812,19.154297 26.336277,19.125697 26.168845,19.110107 26,19.089847 l 0,-2.089844 z"
+       id="path4266"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssccccssscccscccccsscccsssscccccc" />
+    <path
+       sodipodi:nodetypes="ccssccccssscccscccccsscccsssscccccc"
+       inkscape:connector-curvature="0"
+       id="rect3358"
+       d="m 23,16 0,2.060547 C 22.157513,18.16981 21.481481,18.459375 20.978516,18.9375 20.326563,19.557255 20,20.442039 20,21.59375 c 0,0.919303 0.232892,1.649121 0.699219,2.191406 0.470854,0.542286 1.214367,0.937645 2.228515,1.185547 l 1.011719,0.255859 c 0.615733,0.154939 1.024781,0.331089 1.228516,0.527344 0.208262,0.196256 0.3125,0.474414 0.3125,0.835938 0,0.40284 -0.151739,0.712773 -0.455078,0.929687 -0.303339,0.216914 -0.740089,0.326172 -1.310547,0.326172 -0.561404,0 -1.145275,-0.09867 -1.751953,-0.294922 -0.602151,-0.20142 -1.227575,-0.498113 -1.875,-0.890625 l 0,2.517578 c 0.647425,0.273725 1.295934,0.479696 1.943359,0.619141 0.323713,0.06972 0.646169,0.123342 0.96875,0.158203 L 23,32 l 2,0 0,-2.066406 c 0.850366,-0.123185 1.521827,-0.405307 2.001953,-0.855469 C 27.667488,28.453206 28,27.502224 28,26.226562 28,25.255615 27.762491,24.50726 27.287109,23.980469 26.811727,23.453677 26.010147,23.060965 24.882812,22.802734 l -1.113281,-0.255859 c -0.529711,-0.123951 -0.897827,-0.270974 -1.101562,-0.441406 -0.199208,-0.175597 -0.296875,-0.418639 -0.296875,-0.728516 0,-0.41317 0.148454,-0.717807 0.447265,-0.914062 0.298812,-0.196256 0.759978,-0.294922 1.384766,-0.294922 0.470855,0 0.972242,0.07219 1.501953,0.216797 0.529711,0.144609 1.07203,0.358524 1.628906,0.642578 l 0,-2.447266 C 26.704669,18.388987 26.096381,18.24726 25.507812,18.154297 25.336277,18.125697 25.168845,18.110107 25,18.089847 l 0,-2.089844 z"
+       style="fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for Buddi. Fixes #2022
Pushed:
![buddi](https://cloud.githubusercontent.com/assets/7050624/7339793/52193bf6-ec7b-11e4-91b5-8544c6644747.png)
Alt:
![buddi0](https://cloud.githubusercontent.com/assets/7050624/7339794/592543fe-ec7b-11e4-8618-5655d03cf1da.png)

