### PR TITLE
Icon for Rosegarden

### DIFF
--- a/Numix-Circle/48x48/apps/rosegarden.svg
+++ b/Numix-Circle/48x48/apps/rosegarden.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   viewBox="0 0 13.546667 13.546667"
+   height="48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="rosegarden.svg">
+  <metadata
+     id="metadata331">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview329"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="7.194444"
+     inkscape:cy="18.590346"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3308" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4460-9"
+       id="linearGradient4033"
+       x1="-27"
+       y1="13"
+       x2="-24"
+       y2="13"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient4460-9">
+      <stop
+         id="stop4454"
+         style="stop-color:#0cbe82;stop-opacity:1;"
+         offset="0" />
+      <stop
+         id="stop4456"
+         style="stop-color:#0dd18e;stop-opacity:1;"
+         offset="1" />
+    </linearGradient>
+  </defs>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Shadow"
+     sodipodi:insensitive="true">
+    <path
+       style="opacity:0.05;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 25,2 C 12.297451,2 2,12.297451 2,25 2,31.367153 4.6007106,37.116628 8.78125,41.28125 12.865755,44.99361 18.29568,47.25 24.25,47.25 c 12.702549,0 23,-10.297451 23,-23 0,-5.95432 -2.25639,-11.384245 -5.96875,-15.46875 C 37.116628,4.6007105 31.367153,2 25,2 z M 41.28125,8.78125 C 45.135604,12.894061 47.5,18.418655 47.5,24.5 c 0,12.702549 -10.297451,23 -23,23 C 18.418655,47.5 12.894061,45.135604 8.78125,41.28125 12.940939,45.4251 18.664604,48 25,48 37.702549,48 48,37.702549 48,25 48,18.664604 45.4251,12.940939 41.28125,8.78125 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3978"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 41.28125,8.78125 C 44.99361,12.865755 47.25,18.29568 47.25,24.25 c 0,12.702549 -10.297451,23 -23,23 -5.95432,0 -11.384245,-2.25639 -15.46875,-5.96875 C 12.894061,45.135604 18.418655,47.5 24.5,47.5 c 12.702549,0 23,-10.297451 23,-23 0,-6.081345 -2.364396,-11.605939 -6.21875,-15.71875 z"
+       transform="scale(0.28222223,0.28222223)"
+       id="path3976"
+       inkscape:connector-curvature="0" />
+    <path
+       transform="matrix(4.3274074,0,0,3.2455556,117.19278,-35.348334)"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       sodipodi:ry="2"
+       sodipodi:rx="1.5"
+       sodipodi:cy="13"
+       sodipodi:cx="-25.5"
+       id="path3952"
+       style="opacity:0.2;fill:#000000;fill-opacity:1;stroke:none"
+       sodipodi:type="arc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer2"
+     inkscape:label="Base">
+    <path
+       sodipodi:type="arc"
+       style="fill:url(#linearGradient4033);fill-opacity:1.0;stroke:none"
+       id="path3942"
+       sodipodi:cx="-25.5"
+       sodipodi:cy="13"
+       sodipodi:rx="1.5"
+       sodipodi:ry="2"
+       d="m -24,13 a 1.5,2 0 1 1 -3,0 1.5,2 0 1 1 3,0 z"
+       transform="matrix(0,-4.3274075,3.2455556,0,-35.418894,-103.57556)" />
+    <path
+       style="opacity:1;fill:#000000;fill-opacity:0.09803922;fill-rule:nonzero;stroke:none;stroke-width:30.89999962;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 7.0064976,3.3867185 C 6.1859478,3.3868565 5.5018998,3.9364225 5.3445835,4.6666403 5.2847964,4.8953575 5.1414709,5.0497931 4.7481686,5.0800519 l 0.00441,0.00167 C 3.9997483,5.1742899 3.3868234,5.8454279 3.3866668,6.6708593 3.3865703,7.1827847 3.6468483,7.6517602 4.0668664,7.9491276 4.2467952,8.108148 4.3390999,8.328697 4.195851,8.7776044 l 0.00772,-0.0061 c -0.020224,0.0988 -0.034541,0.198773 -0.034727,0.300412 1.673e-4,0.883701 0.7592608,1.6000206 1.6960895,1.6001786 0.1692033,-1.84e-4 0.334925,-0.02885 0.4944401,-0.07497 l -0.00717,0.0077 c 0.019778,-0.0084 0.032047,-0.01055 0.050712,-0.01819 0.0275,-0.0087 0.054035,-0.01919 0.081029,-0.02921 0.3509063,-0.13151 0.5330238,-0.106972 0.9536026,0.04906 0.1992182,0.07592 0.4125943,0.117548 0.6311415,0.11796 0.9372104,-1.57e-4 1.6970091,-0.71722 1.6966405,-1.6012806 -2.54e-4,-0.112202 -0.01719,-0.222584 -0.041892,-0.331281 l 0.00277,0.0033 C 9.6933754,8.4050238 9.8165166,8.1856058 10.131897,7.9529876 l -0.0017,5.644e-4 C 10.496794,7.6562368 10.724352,7.2205704 10.724443,6.7430831 10.72429,5.939606 10.256169,5.2867421 9.1937176,5.1649536 8.8437674,5.0549985 8.7557002,4.9596198 8.6634486,4.6429529 8.4961805,3.9244927 7.8183454,3.38644 7.0064953,3.3867332 Z m 0.049058,2.4710981 c 0.072141,0 0.1442616,0.027954 0.1995399,0.083233 0,0 0.1512186,0.2195635 0.2678907,0.2678907 0.1167895,0.048376 0.3792361,0 0.3792361,0 0.1563511,0 0.2822222,0.1258711 0.2822222,0.2822222 0,0 -0.048376,0.2624467 0,0.3792362 0.048327,0.116672 0.2678907,0.2678907 0.2678907,0.2678907 0.1105569,0.1105569 0.1105569,0.2885228 0,0.3990797 0,0 -0.2195635,0.1512186 -0.2678907,0.2678907 -0.048376,0.1167895 0,0.3792361 0,0.3792361 0,0.1563511 -0.1258711,0.2822223 -0.2822222,0.2822223 0,0 -0.2624466,-0.048376 -0.3792361,0 -0.1166721,0.048327 -0.2678907,0.2678907 -0.2678907,0.2678907 -0.1105569,0.1105565 -0.2885229,0.1105565 -0.3990798,0 0,0 -0.1512186,-0.2195636 -0.2678907,-0.2678907 -0.1167895,-0.048376 -0.3792361,0 -0.3792361,0 -0.1563511,0 -0.2822222,-0.1258712 -0.2822222,-0.2822223 0,0 0.048376,-0.2624466 0,-0.3792361 C 5.8783396,7.6885882 5.6587761,7.5373696 5.6587761,7.5373696 c -0.1105569,-0.1105569 -0.1105569,-0.2885228 0,-0.3990797 0,0 0.2195635,-0.1512187 0.2678907,-0.2678907 0.048376,-0.1167895 0,-0.3792362 0,-0.3792362 0,-0.1563511 0.1258711,-0.2822222 0.2822222,-0.2822222 0,0 0.2624466,0.048376 0.3792361,0 0.1166721,-0.048327 0.2678907,-0.2678907 0.2678907,-0.2678907 0.055278,-0.055278 0.1273985,-0.083233 0.1995399,-0.083233 z m 0,0.6333464 A 0.84666669,0.84666669 0 0 0 6.208889,7.3378297 0.84666669,0.84666669 0 0 0 7.0555557,8.1844964 0.84666669,0.84666669 0 0 0 7.9022224,7.3378297 0.84666669,0.84666669 0 0 0 7.0555557,6.491163 Z"
+       id="path4267"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none"
+       d="M 40.03125 7.53125 C 43.74361 11.615755 46 17.04568 46 23 C 46 35.702549 35.702549 46 23 46 C 17.04568 46 11.615755 43.74361 7.53125 40.03125 C 11.709416 44.322508 17.537578 47 24 47 C 36.702549 47 47 36.702549 47 24 C 47 17.537578 44.322508 11.709416 40.03125 7.53125 z "
+       id="path4027"
+       transform="scale(0.28222223,0.28222223)" />
+    <g
+       id="g4230">
+      <g
+         style="fill:#e8e070;fill-opacity:1"
+         transform="matrix(0.28222223,0,0,-0.28222223,4.062701e-8,13.828889)"
+         id="g4166">
+        <g
+           style="fill:#e8e070;fill-opacity:1"
+           id="g4224">
+          <path
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:30.89999962;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+             d="m 23.826172,11 c -3.319473,5.58e-4 -6.009173,2.538695 -6.009766,5.669922 0.0014,0.15431 0.0087,0.309201 0.02344,0.46289 -0.467414,-0.109094 -0.94623,-0.164815 -1.427737,-0.166015 C 13.490386,17 11.000594,19.505494 11,22.636719 c -4.42e-4,2.341958 1.524697,4.443163 3.839844,5.289062 -0.69448,0.945828 -1.06626,2.068212 -1.06836,3.21875 5.93e-4,3.131226 2.690294,5.669364 6.009766,5.669922 1.381946,-0.0015 2.721945,-0.451597 3.792969,-1.275391 1.101686,0.938103 2.531465,1.458138 4.015625,1.460938 3.320824,-5.56e-4 6.013024,-2.541327 6.011718,-5.673828 -0.0024,-1.059125 -0.318803,-2.096106 -0.914062,-2.994141 2.557013,-0.710494 4.312025,-2.924981 4.3125,-5.439453 -5.94e-4,-3.132496 -1.999583,-5.626952 -6.613281,-5.669922 -0.195921,7.4e-4 -0.392983,0.01053 -0.587891,0.0293 0.0244,-0.193409 0.03977,-0.387281 0.04297,-0.582031 C 29.841204,13.537424 27.146992,10.9988 23.826172,11 Z M 24,19.755859 c 0.255619,0 0.511163,0.09905 0.707031,0.294922 0,0 0.535814,0.777981 0.949219,0.949219 C 26.070071,21.17141 27,21 27,21 c 0.554,0 1,0.446 1,1 0,0 -0.17141,0.929929 0,1.34375 0.171238,0.413405 0.949219,0.949219 0.949219,0.949219 0.391737,0.391737 0.391737,1.022325 0,1.414062 0,0 -0.777981,0.535814 -0.949219,0.949219 C 27.82859,27.070071 28,28 28,28 c 0,0.554 -0.446,1 -1,1 0,0 -0.929929,-0.17141 -1.34375,0 -0.413405,0.171238 -0.949219,0.949219 -0.949219,0.949219 -0.391737,0.391737 -1.022325,0.391737 -1.414062,0 0,0 -0.535814,-0.777981 -0.949219,-0.949219 C 21.929929,28.82859 21,29 21,29 c -0.554,0 -1,-0.446 -1,-1 0,0 0.17141,-0.929929 0,-1.34375 -0.171238,-0.413405 -0.949219,-0.949219 -0.949219,-0.949219 -0.391737,-0.391737 -0.391737,-1.022325 0,-1.414062 0,0 0.777981,-0.535814 0.949219,-0.949219 C 20.17141,22.929929 20,22 20,22 c 0,-0.554 0.446,-1 1,-1 0,0 0.929929,0.17141 1.34375,0 0.413405,-0.171238 0.949219,-0.949219 0.949219,-0.949219 C 23.488837,19.854913 23.744381,19.755859 24,19.755859 Z"
+             transform="matrix(1,0,0,-1,0,49)"
+             id="path4176"
+             inkscape:connector-curvature="0"
+             sodipodi:nodetypes="ccccsccccccccccccssssssssssssssssssssssssss" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path4256"
+             d="m 33.462241,18.835938 c -0.116318,1.382672 0.321312,2.160135 1.438803,2.984374 L 31.583335,21.21875 Z"
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path4273"
+             d="m 21.507618,12.42369 c 1.695645,0.722094 2.182395,0.629422 4.057579,-0.07734 l -2.046743,2.132369 z"
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path4275"
+             d="m 13.867415,18.898136 c 0.596887,1.870494 0.04287,2.626802 -0.817415,3.219032 l 3.905483,-0.611575 z"
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path4277"
+             d="m 15.825,32 c 1.471783,0.113232 1.969103,0.706001 2.158203,1.59375 l 0.660156,-2.75 z"
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+          <path
+             sodipodi:nodetypes="cccc"
+             inkscape:connector-curvature="0"
+             id="path4279"
+             d="m 29.659067,33.664352 c 0.408514,-1.447728 0.627115,-1.635625 2.611952,-2.179799 l -3.942593,-1.427388 z"
+             style="opacity:1;fill:#f2f192;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+        </g>
+      </g>
+      <circle
+         r="0.84666669"
+         cy="7.0555558"
+         cx="6.773334"
+         id="path4160"
+         style="fill:#9f8e6b;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4261"
+       style="fill:#000000">
+      <g
+         id="g4263"
+         transform="matrix(0.28222223,0,0,-0.28222223,4.062701e-8,13.828889)"
+         style="fill:#000000;fill-opacity:1">
+        <g
+           id="g4265"
+           style="fill:#000000;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="layer3"
+     inkscape:label="Symbol" />
+</svg>


### PR DESCRIPTION
Icon for Rosegarden. Fixes #1090
![rosegarden](https://cloud.githubusercontent.com/assets/7050624/7346346/bebcaf10-ecdd-11e4-9e60-cc8fab5f96a4.png)

Btw, some magnificent new icons by you lately @Foggalong :+1: 
