### PR TITLE
Icon for PeaZip

### DIFF
--- a/Numix-Circle/48x48/apps/peazip.svg
+++ b/Numix-Circle/48x48/apps/peazip.svg
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg137"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="peazip2.svg">
+  <metadata
+     id="metadata196">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview194"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="0"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg137" />
+  <defs
+     id="defs139">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         stop-color="#6cb85a"
+         stop-opacity="1"
+         id="stop142" />
+      <stop
+         offset="1"
+         stop-color="#79be69"
+         stop-opacity="1"
+         id="stop144" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g156">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path158" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path160" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path162" />
+  </g>
+  <g
+     id="g164">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       fill="url(#linearGradient3764)"
+       fill-opacity="1"
+       id="path166" />
+  </g>
+  <g
+     id="g168" />
+  <g
+     id="g190">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path192" />
+  </g>
+  <path
+     style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     d="m 15.875,11.999998 c -0.492,0 -0.874999,0.383 -0.874999,0.875 l 0,24.25 C 15.000001,37.616997 15.383,38 15.875,38 l 18.25,0 c 0.492,0 0.874999,-0.383003 0.874999,-0.875002 0,-6.375 0,-12.75 0,-19.125 l -5.999999,-6 c -4.375,0 -8.75,0 -13.125,0 z"
+     id="path4332"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="csssscccc" />
+  <g
+     transform="scale(3.543307,3.543307)"
+     id="g3426">
+    <path
+       sodipodi:nodetypes="cssssscc"
+       style="fill:#e8e8d9;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 4.1980557,3.1044445 c -0.1388533,0 -0.2469445,0.1080911 -0.2469445,0.2469445 l 0,6.843889 c 0,0.138853 0.1080912,0.246945 0.2469445,0.246945 l 5.1505557,0 c 0.1388533,0 0.2469445,-0.108092 0.2469445,-0.246945 l -1e-7,-5.3975001 -1.6933334,-1.6933334"
+       id="path67" />
+    <path
+       sodipodi:nodetypes="ccc"
+       style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 7.9022224,3.1044445 0,1.6933334 1.6933334,0"
+       id="path79" />
+    <path
+       sodipodi:nodetypes="ccc"
+       style="fill:#000000;fill-opacity:0.2;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 9.5955558,6.4911113 0,-1.6933334 -1.6933334,0"
+       id="SVGCleanerId_0" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4089"
+       d="m 5.6444499,3.6688837 0,0.5644497 0.5644496,0 0,-0.5644497 -0.5644496,0 z"
+       style="fill:#aaaaaa" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4087"
+       d="m 5.6444499,4.2333334 -0.5644497,0 0,0.5644496 0.5644497,0 0,-0.5644496 z"
+       style="fill:#aaaaaa" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4085"
+       d="m 5.6444499,4.797783 0,0.5644496 0.5644496,0 0,-0.5644496 -0.5644496,0 z"
+       style="fill:#aaaaaa" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4083"
+       d="m 5.6444499,5.3622326 -0.5644497,0 0,0.5644497 0.5644497,0 0,-0.5644497 z"
+       style="fill:#aaaaaa" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path4081"
+       d="m 5.6444499,5.9266823 0,0.5644496 0.5644496,0 0,-0.5644496 -0.5644496,0 z"
+       style="fill:#aaaaaa" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3279"
+       d="m 5.0800002,6.7733567 0,1.1288993 1.1288993,0 0,-1.1288993 -0.5644496,0 -0.5644497,0 z"
+       style="fill:#aaaaaa" />
+    <path
+       style="fill:#aaaaaa"
+       d="m 5.0800105,3.1044445 0,0.5644497 0.5644496,0 0,-0.5644497 -0.5644496,0 z"
+       id="path4112"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>


### PR DESCRIPTION
Icon for PeaZip. Fixes #2030
![peazip](https://cloud.githubusercontent.com/assets/7050624/7352451/ed665b3a-ed0b-11e4-8c8f-0e9ab36b2f8d.png)

