### PR TITLE
Added unity-launcherswitcher.svg

### DIFF
--- a/Numix-Circle/48x48/apps/unity-launcherswitcher.svg
+++ b/Numix-Circle/48x48/apps/unity-launcherswitcher.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="unity-launcherswitcher_8b.svg">
+  <metadata
+     id="metadata40">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview38"
+     showgrid="true"
+     inkscape:zoom="12.291667"
+     inkscape:cx="23.999999"
+     inkscape:cy="23.999999"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4168" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <clipPath
+       id="clipPath6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g8">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path10" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath12">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g14">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           fill="#1890d0"
+           id="path16" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g18">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path20" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path22" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path24" />
+  </g>
+  <path
+     d="M 24 1 C 11.297 1 1 11.297 1 24 L 24 24 L 24 1 z "
+     fill="#ec6853"
+     fill-rule="evenodd"
+     stroke="none"
+     fill-opacity="1"
+     id="path26"
+     style="fill:#ec6853;fill-opacity:1" />
+  <path
+     d="m 1 24 c 0 12.703 10.297 23 23 23 l 0 -23 l -23 0 z"
+     fill="#d6d6d6"
+     fill-rule="evenodd"
+     stroke="none"
+     fill-opacity="1"
+     id="path28"
+     style="fill:#87d58e;fill-opacity:1" />
+  <path
+     d="m 24 24 l 0 23 c 12.703 0 23 -10.297 23 -23 l -23 0 z"
+     fill="#e6e6e6"
+     fill-rule="evenodd"
+     stroke="none"
+     fill-opacity="1"
+     id="path30"
+     style="fill:#8b99fa;fill-opacity:1" />
+  <path
+     d="M 24 1 L 24 24 L 47 24 C 47 11.297 36.703 1 24 1 z "
+     fill="#f9f9f9"
+     fill-rule="evenodd"
+     stroke="none"
+     fill-opacity="1"
+     id="path32"
+     style="fill:#f0db6b;fill-opacity:1" />
+  <g
+     id="g34">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path36" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/numixproject/numix-icon-theme-circle/issues/2037.

![unity-launcherswitcher](https://cloud.githubusercontent.com/assets/7164227/7420316/aeb69d60-ef7b-11e4-8d0d-b38523073f9e.png)

This icon takes `workspace-switcher-top-left.svg` as a starting point and then adapts the colours to the original icon while leaving the red colour the same.

![unity-launcherswitcher_2](https://cloud.githubusercontent.com/assets/7164227/7420336/e68491ac-ef7b-11e4-9c28-2db35fe74d06.png)
