### PR TITLE
Added unsettings.svg

### DIFF
--- a/Numix-Circle/48x48/apps/unsettings.svg
+++ b/Numix-Circle/48x48/apps/unsettings.svg
@@ -1,0 +1,344 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="unsettings_2.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview63"
+     showgrid="true"
+     showguides="true"
+     inkscape:zoom="12.291667"
+     inkscape:cx="23.999999"
+     inkscape:cy="23.999999"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3393" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         offset="0"
+         stop-color="#e2a8bf"
+         stop-opacity="1"
+         id="stop7"
+         style="stop-color:#e2a8db;stop-opacity:1" />
+      <stop
+         offset="1"
+         stop-color="#e7b7e1"
+         stop-opacity="1"
+         id="stop9"
+         style="stop-color:#e7b7e1;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#3764"
+       id="linearGradient5815"
+       x1="24"
+       y1="47"
+       x2="24"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <clipPath
+       id="clipPath-592456933-1-6">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4-3">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-8" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-592456933-1-1-9">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4-38-0">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-5-6" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-592456933-1-1-9-1">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4-38-0-8">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-5-6-5" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-592456933-1-1-9-1-5">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4-38-0-8-3">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-5-6-5-6" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-592456933-1-1-9-8">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-4-38-0-7">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-5-6-3" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       id="path31"
+       style="fill:url(#linearGradient5815);fill-opacity:1"
+       fill-opacity="1"
+       fill="url(#linearGradient3764)" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+  <g
+     id="g4198-5"
+     transform="translate(9,-10)"
+     style="fill:#0000ff;fill-opacity:0">
+    <g
+       transform="matrix(0.90795448,0,0,0.96488326,1.3785102,1.1316484)"
+       id="text4201-2"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#0000ff;fill-opacity:0;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1">
+      <path
+         style="fill:#0000ff;fill-opacity:0"
+         sodipodi:nodetypes="ssccsccsssscccscccs"
+         inkscape:connector-curvature="0"
+         id="path4206-2"
+         d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z" />
+    </g>
+    <g
+       style="fill:#0000ff;fill-opacity:0"
+       id="g47-3"
+       transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,4.0974988)">
+      <g
+         style="fill:#0000ff;fill-opacity:0"
+         id="g49-4"
+         clip-path="url(#clipPath-592456933-1-6)">
+        <!-- color: #e8a23b -->
+        <g
+           style="fill:#0000ff;fill-opacity:0"
+           id="g51-6">
+          <path
+             sodipodi:nodetypes="ccssssccccccccccsssss"
+             id="path53-7"
+             d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
+             inkscape:connector-curvature="0"
+             style="fill:#0000ff;fill-opacity:0;fill-rule:nonzero;stroke:none" />
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     transform="translate(1,1)"
+     id="g4291-5"
+     style="opacity:0.1;fill:#000000;fill-opacity:1">
+    <g
+       style="opacity:0.1;fill:#000000;fill-opacity:1"
+       id="g4183-7-1"
+       transform="translate(1,1)">
+      <g
+         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
+         id="g47-5-6-7-9"
+         style="fill:#000000;fill-opacity:1">
+        <g
+           clip-path="url(#clipPath-592456933-1-1-9-1-5)"
+           id="g49-3-3-8-4"
+           style="fill:#000000;fill-opacity:1">
+          <!-- color: #e8a23b -->
+          <g
+             id="g51-8-7-3-8"
+             style="fill:#000000;fill-opacity:1" />
+        </g>
+      </g>
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4201-3-5-6-1"
+         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)" />
+    </g>
+    <g
+       id="g4183-0"
+       style="fill:#000000;fill-opacity:1">
+      <g
+         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
+         id="g47-5-6-9"
+         style="fill:#000000;fill-opacity:1">
+        <g
+           clip-path="url(#clipPath-592456933-1-1-9-8)"
+           id="g49-3-3-4"
+           style="fill:#000000;fill-opacity:1">
+          <!-- color: #e8a23b -->
+          <g
+             id="g51-8-7-9"
+             style="fill:#000000;fill-opacity:1">
+            <path
+               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
+               id="path53-5-1-9"
+               sodipodi:nodetypes="ccccccccccccccccccccc" />
+          </g>
+        </g>
+      </g>
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4201-3-5-1"
+         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)">
+        <path
+           d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z"
+           id="path4206-24-9-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccc"
+           style="fill:#000000;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g4291">
+    <g
+       style="opacity:0.1;fill:#000000;fill-opacity:1"
+       id="g4183-7"
+       transform="translate(1,1)">
+      <g
+         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
+         id="g47-5-6-7"
+         style="fill:#000000;fill-opacity:1">
+        <g
+           clip-path="url(#clipPath-592456933-1-1-9-1)"
+           id="g49-3-3-8"
+           style="fill:#000000;fill-opacity:1">
+          <!-- color: #e8a23b -->
+          <g
+             id="g51-8-7-3"
+             style="fill:#000000;fill-opacity:1" />
+        </g>
+      </g>
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4201-3-5-6"
+         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)" />
+    </g>
+    <g
+       id="g4183">
+      <g
+         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
+         id="g47-5-6"
+         style="fill:#77216f;fill-opacity:1">
+        <g
+           clip-path="url(#clipPath-592456933-1-1-9)"
+           id="g49-3-3"
+           style="fill:#77216f;fill-opacity:1">
+          <!-- color: #e8a23b -->
+          <g
+             id="g51-8-7"
+             style="fill:#77216f;fill-opacity:1">
+            <path
+               style="fill:#77216f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+               inkscape:connector-curvature="0"
+               d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
+               id="path53-5-1"
+               sodipodi:nodetypes="ccccccccccccccccccccc" />
+          </g>
+        </g>
+      </g>
+      <g
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#77216f;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         id="text4201-3-5"
+         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)">
+        <path
+           d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z"
+           id="path4206-24-9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccccccccc"
+           style="fill:#77216f;fill-opacity:1" />
+      </g>
+    </g>
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/unsettings.svg
+++ b/Numix-Circle/48x48/apps/unsettings.svg
@@ -12,7 +12,7 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r"
-   sodipodi:docname="unsettings_2.svg">
+   sodipodi:docname="unsettings_3.svg">
   <metadata
      id="metadata65">
     <rdf:RDF>
@@ -40,8 +40,8 @@
      showgrid="true"
      showguides="true"
      inkscape:zoom="12.291667"
-     inkscape:cx="23.999999"
-     inkscape:cy="23.999999"
+     inkscape:cx="24"
+     inkscape:cy="24"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -217,128 +217,94 @@
     </g>
   </g>
   <g
-     transform="translate(1,1)"
-     id="g4291-5"
-     style="opacity:0.1;fill:#000000;fill-opacity:1">
+     transform="translate(2,2)"
+     id="g4183-7-1"
+     style="opacity:0.01000001;fill:#000000;fill-opacity:1">
     <g
-       style="opacity:0.1;fill:#000000;fill-opacity:1"
-       id="g4183-7-1"
-       transform="translate(1,1)">
+       style="fill:#000000;fill-opacity:1"
+       id="g47-5-6-7-9"
+       transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)">
       <g
-         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
-         id="g47-5-6-7-9"
-         style="fill:#000000;fill-opacity:1">
+         style="fill:#000000;fill-opacity:1"
+         id="g49-3-3-8-4"
+         clip-path="url(#clipPath-592456933-1-1-9-1-5)">
+        <!-- color: #e8a23b -->
         <g
-           clip-path="url(#clipPath-592456933-1-1-9-1-5)"
-           id="g49-3-3-8-4"
-           style="fill:#000000;fill-opacity:1">
-          <!-- color: #e8a23b -->
-          <g
-             id="g51-8-7-3-8"
-             style="fill:#000000;fill-opacity:1" />
-        </g>
+           style="fill:#000000;fill-opacity:1"
+           id="g51-8-7-3-8" />
       </g>
-      <g
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="text4201-3-5-6-1"
-         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)" />
     </g>
     <g
-       id="g4183-0"
-       style="fill:#000000;fill-opacity:1">
-      <g
-         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
-         id="g47-5-6-9"
-         style="fill:#000000;fill-opacity:1">
-        <g
-           clip-path="url(#clipPath-592456933-1-1-9-8)"
-           id="g49-3-3-4"
-           style="fill:#000000;fill-opacity:1">
-          <!-- color: #e8a23b -->
-          <g
-             id="g51-8-7-9"
-             style="fill:#000000;fill-opacity:1">
-            <path
-               style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
-               id="path53-5-1-9"
-               sodipodi:nodetypes="ccccccccccccccccccccc" />
-          </g>
-        </g>
-      </g>
-      <g
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="text4201-3-5-1"
-         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)">
-        <path
-           d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z"
-           id="path4206-24-9-9"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccccccccc"
-           style="fill:#000000;fill-opacity:1" />
-      </g>
+       transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)"
+       id="text4201-3-5-6-1"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     style="fill:#000000;fill-opacity:1"
+     id="g49-3-3-4"
+     clip-path="url(#clipPath-592456933-1-1-9-8)"
+     transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,24.999544,4.0974988)">
+    <!-- color: #e8a23b -->
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g51-8-7-9">
+      <path
+         sodipodi:nodetypes="ccccccccccccccccccccc"
+         id="path53-5-1-9"
+         d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
+         inkscape:connector-curvature="0"
+         style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;opacity:0.1" />
     </g>
   </g>
   <g
-     id="g4291">
-    <g
-       style="opacity:0.1;fill:#000000;fill-opacity:1"
-       id="g4183-7"
-       transform="translate(1,1)">
-      <g
-         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
-         id="g47-5-6-7"
-         style="fill:#000000;fill-opacity:1">
-        <g
-           clip-path="url(#clipPath-592456933-1-1-9-1)"
-           id="g49-3-3-8"
-           style="fill:#000000;fill-opacity:1">
-          <!-- color: #e8a23b -->
-          <g
-             id="g51-8-7-3"
-             style="fill:#000000;fill-opacity:1" />
-        </g>
-      </g>
-      <g
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="text4201-3-5-6"
-         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)" />
-    </g>
-    <g
-       id="g4183">
-      <g
-         transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)"
-         id="g47-5-6"
-         style="fill:#77216f;fill-opacity:1">
-        <g
-           clip-path="url(#clipPath-592456933-1-1-9)"
-           id="g49-3-3"
-           style="fill:#77216f;fill-opacity:1">
-          <!-- color: #e8a23b -->
-          <g
-             id="g51-8-7"
-             style="fill:#77216f;fill-opacity:1">
-            <path
-               style="fill:#77216f;fill-opacity:1;fill-rule:nonzero;stroke:none"
-               inkscape:connector-curvature="0"
-               d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
-               id="path53-5-1"
-               sodipodi:nodetypes="ccccccccccccccccccccc" />
-          </g>
-        </g>
-      </g>
-      <g
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#77216f;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-         id="text4201-3-5"
-         transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)">
-        <path
-           d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z"
-           id="path4206-24-9"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccccccccccccccccc"
-           style="fill:#77216f;fill-opacity:1" />
-      </g>
-    </g>
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     id="text4201-3-5-1"
+     transform="matrix(0.90795448,0,0,0.96488326,2.3785102,1.1316485)">
+    <path
+       d="m 24.914784,38.210168 c -1.898444,0 -3.545624,-0.293142 -4.941539,-0.879426 C 18.577331,36.744457 17.43268,35.948786 16.539295,34.943727 15.64591,33.91075 14.975871,32.696304 14.529178,31.30039 14.110403,29.904475 13.901016,28.396887 13.901016,26.777626 l 0,-13.440933 4.405507,0 0,12.980281 c 0,2.903502 0.298726,5.011334 1.582968,6.323494 1.284242,1.312159 2.959395,1.953934 5.025293,1.96824 2.083039,0.01443 3.635149,-0.623016 5.025293,-1.96824 1.327422,-1.284528 1.54643,-4.202036 1.582968,-6.323494 l 0,-12.980281 4.405507,0 0,13.440933 c 0,1.619261 -0.223346,3.126849 -0.670039,4.522764 -0.418775,1.395914 -1.088814,2.61036 -2.010118,3.643337 -0.893385,1.005059 -2.038036,1.80073 -3.43395,2.387015 -1.367997,0.586284 -3.001217,0.879426 -4.899661,0.879426 z"
+       id="path4206-24-9-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccc"
+       style="fill:#000000;fill-opacity:1;opacity:0.1" />
   </g>
+  <g
+     transform="translate(1,1)"
+     id="g4183-7"
+     style="opacity:0.1;fill:#000000;fill-opacity:1">
+    <g
+       style="fill:#000000;fill-opacity:1"
+       id="g47-5-6-7"
+       transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)">
+      <g
+         style="fill:#000000;fill-opacity:1"
+         id="g49-3-3-8"
+         clip-path="url(#clipPath-592456933-1-1-9-1)">
+        <!-- color: #e8a23b -->
+        <g
+           style="fill:#000000;fill-opacity:1"
+           id="g51-8-7-3" />
+      </g>
+    </g>
+    <g
+       transform="matrix(0.90795448,0,0,0.96488326,1.3785102,0.13164854)"
+       id="text4201-3-5-6"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  </g>
+  <g
+     id="g51-8-7"
+     style="fill:#77216f;fill-opacity:1"
+     transform="matrix(0.4571437,0.38958561,-0.45701485,0.38947587,23.999544,3.0974988)">
+    <path
+       style="fill:#77216f;fill-opacity:1;fill-rule:nonzero;stroke:none"
+       inkscape:connector-curvature="0"
+       d="m 17.609,10 c -0.918,0.016 -1.845316,0.189317 -2.712316,0.524317 l 4.656,4.656 c 0.793467,0.793467 1.149594,1.928407 0.868594,3.022407 -0.281,1.094 -1.132819,1.941453 -2.223,2.223 -1.089819,0.281453 -2.22375,-0.07234 -3.021203,-0.869798 L 10.521692,14.900542 C 9.4396923,17.670542 10.018,20.969 12.257,23.2 c 2.238,2.238 5.526637,2.813364 8.296637,1.731364 l 12.1,12.11 c 0.773,0.82 1.942363,1.147636 3.024363,0.870636 1.09,-0.273 1.938,-1.133 2.223,-2.223 0.281,-1.09 -0.04726,-2.253745 -0.867256,-3.023745 l -12.1,-12.1 C 26.015744,17.795255 25.442,14.499 23.203,12.268 21.668,10.729 19.633,9.983 17.613,10.014 m 18.197983,25.806082 c -0.548487,0.548642 -1.736768,0.450855 -2.377163,-0.189721 -0.640395,-0.640576 -0.738088,-1.829258 -0.189667,-2.377833 0.548421,-0.548575 1.730748,-0.456876 2.377163,0.189721 0.646415,0.646597 0.738154,1.829191 0.189667,2.377833 z"
+       id="path53-5-1"
+       sodipodi:nodetypes="ccccccccccccccccccccc" />
+  </g>
+  <path
+     style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:125%;font-family:Ubuntu;-inkscape-font-specification:Ubuntu;letter-spacing:0px;word-spacing:0px;fill:#77216f;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     sodipodi:nodetypes="ccccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4206-24-9"
+     d="M 24,37 C 22.276299,37 20.780735,36.717152 19.513307,36.151457 18.245881,35.58576 17.20659,34.81803 16.395437,33.848266 15.584284,32.851564 14.975919,31.679765 14.570342,30.332871 14.190114,28.985976 14,27.531329 14,25.968932 L 14,13 l 4,0 0,12.524456 c 0,2.801541 0.271229,4.835352 1.437263,6.101434 1.166033,1.26608 2.686996,1.885318 4.562737,1.899122 1.891305,0.01392 3.30055,-0.601138 4.562737,-1.899122 C 29.767976,30.38647 29.966825,27.571416 30,25.524456 L 30,13 l 4,0 0,12.968932 c 0,1.562397 -0.202788,3.017044 -0.608365,4.363939 -0.380229,1.346894 -0.988594,2.518693 -1.825096,3.515395 -0.811153,0.969764 -1.850444,1.737494 -3.11787,2.303191 C 27.20659,36.717152 25.723701,37 24,37 Z" />
 </svg>


### PR DESCRIPTION
Fixes https://github.com/numixproject/numix-icon-theme-circle/issues/2036.

This is the icon in Inkscape:

![unsettings](https://cloud.githubusercontent.com/assets/7164227/7434886/baecd310-f03e-11e4-963e-eef25d5e7c1b.png)

and here showing in the Ubuntu 14.10 system settings in the upper right:

![system-settings](https://cloud.githubusercontent.com/assets/7164227/7434895/d176cea6-f03e-11e4-82b1-5fc989e147e2.png)

I am wondering though: for some reason, the drop shadow of the center part is not displayed properly with the Ubuntu default image viewer eog:

![unsettings_viewer](https://cloud.githubusercontent.com/assets/7164227/7434946/2df62686-f03f-11e4-886e-6b8cd74dc9a4.png)

and on GitHub "View", the center part is not showing at all, only the "U". And the file size appears to be a bit bigger than usual. Could you point me to what might be wrong here, if s.th. is wrong? Thanks!
