### PR TITLE
Symlink for gxine

### DIFF
--- a/Numix-Circle/48x48/apps/gxine.svg
+++ b/Numix-Circle/48x48/apps/gxine.svg
@@ -1,0 +1,1 @@
+xine.svg


### PR DESCRIPTION
Fixes #2059
Symlink to [xine.svg](https://github.com/numixproject/numix-icon-theme-circle/blob/master/Numix-Circle/48x48/apps/xine.svg)