### PR TITLE
Symlink for Regexxer

### DIFF
--- a/Numix-Circle/48x48/apps/regexxer.svg
+++ b/Numix-Circle/48x48/apps/regexxer.svg
@@ -1,0 +1,1 @@
+search.svg


### PR DESCRIPTION
Symlink to [search.svg](https://github.com/numixproject/numix-icon-theme-circle/blob/master/Numix-Circle/48x48/apps/search.svg) for Regexxer. Fixes #2090
