### PR TITLE
Icon for MKVToolNix on Arch Linux

### DIFF
--- a/Numix-Circle/48x48/apps/mkvtoolnix-gui.svg
+++ b/Numix-Circle/48x48/apps/mkvtoolnix-gui.svg
@@ -1,0 +1,1 @@
+mkvmergeGUI.svg


### PR DESCRIPTION
There is a new icon name in the package desktop file. I added a symlink.