### PR TITLE
Added icon for Pogo

### DIFF
--- a/Numix-Circle/48x48/apps/pogo.svg
+++ b/Numix-Circle/48x48/apps/pogo.svg
@@ -1,0 +1,147 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r"
+   sodipodi:docname="pogo.svg">
+  <metadata
+     id="metadata65">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1215"
+     inkscape:window-height="776"
+     id="namedview63"
+     showgrid="true"
+     inkscape:zoom="12.708333"
+     inkscape:cx="24"
+     inkscape:cy="24"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:object-paths="false"
+     inkscape:snap-intersection-paths="false"
+     inkscape:object-nodes="false"
+     inkscape:snap-smooth-nodes="false"
+     showguides="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4193" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-0.07869003,47.842621)">
+      <stop
+         id="stop7"
+         style="stop-color:#cac8a0;stop-opacity:1" />
+      <stop
+         offset="1"
+         id="stop9"
+         style="stop-color:#d1cfad;stop-opacity:1" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-149002448-1">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17-3-2">
+        <path
+           style="fill:#1890d0"
+           inkscape:connector-curvature="0"
+           d="m -24,13 c 0,1.105 -0.672,2 -1.5,2 -0.828,0 -1.5,-0.895 -1.5,-2 0,-1.105 0.672,-2 1.5,-2 0.828,0 1.5,0.895 1.5,2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           id="path19-0-7" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <path
+     inkscape:connector-curvature="0"
+     style="fill:url(#linearGradient3764);fill-opacity:1"
+     id="path31"
+     d="m 23.921311,0.84262295 c 12.703,0 23,10.29700005 23,23.00000005 0,12.703 -10.297,23 -23,23 -12.703,0 -22.99999953,-10.297 -22.99999953,-23 0,-12.703 10.29699953,-23.00000005 22.99999953,-23.00000005 z" />
+  <path
+     style="fill:#000000;fill-opacity:1;stroke:none;opacity:0.1"
+     d="m 25.376953,10 c -1.712239,0.02104 -3.643196,0.590394 -5.570312,1.591797 C 16.268083,13.43058 13.882329,16.137289 14.009766,19 L 14,19 14,44.609375 c 0.731683,0.343527 1.206197,0.541516 2,0.833984 l 0,-22.552734 c 2.195843,1.718418 5.697025,1.334419 9.193359,-0.482422 4.404831,-2.288934 7.029963,-5.92185 5.234375,-9.527344 C 29.417721,10.852776 27.578403,9.9729487 25.376953,10 Z m 1.785156,3.044922 c 0.68644,-0.02152 1.223347,0.186645 1.503907,0.75 0.897797,1.80275 -2.624664,3.634454 -5.267578,5.007812 -2.642886,1.373354 -6.166658,3.205094 -7.064454,1.402344 -0.89779,-1.802736 2.624689,-3.634467 5.267578,-5.007812 1.817001,-0.94419 4.05038,-2.105006 5.560547,-2.152344 z"
+     id="path31-1-2"
+     inkscape:connector-curvature="0" />
+  <g
+     transform="matrix(-0.02664949,0.55012563,-0.59303036,-0.03428822,40.673974,8.0372163)"
+     id="g47-1"
+     style="fill:#000000;fill-opacity:1;stroke:none;opacity:0.1">
+    <g
+       clip-path="url(#clipPath-149002448-1)"
+       id="g49-4"
+       transform="matrix(0.8660254,-0.45104712,0.55426581,0.8660254,-15.934935,19.871643)"
+       style="fill:#000000;fill-opacity:1;stroke:none">
+      <!-- color: #e7e7e7 -->
+      <g
+         id="g51-9"
+         style="fill:#000000;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <g
+     id="g33" />
+  <path
+     sodipodi:nodetypes="ccccc"
+     inkscape:connector-curvature="0"
+     id="path31-1"
+     d="m 13,17.8 0,26.29914 c 0.624048,0.353906 1.341368,0.672772 2,0.964127 L 15,17.8 Z"
+     style="fill:#3b3b3b;fill-opacity:1;stroke:none" />
+  <path
+     sodipodi:nodetypes="ssssssssss"
+     id="path53"
+     d="m 18.806626,10.591771 c -4.40483,2.288934 -7.030911,5.922797 -5.235332,9.528279 1.795591,3.605492 6.217246,3.577103 10.622077,1.28817 4.40483,-2.288934 7.03092,-5.922786 5.235332,-9.52828 -1.79558,-3.6054813 -6.21724,-3.577089 -10.622077,-1.288169 z m 3.591154,7.210981 c -2.642885,1.373354 -6.166759,3.204482 -7.064555,1.401732 -0.89779,-1.802736 2.626081,-3.633873 5.268971,-5.007219 2.642911,-1.373367 6.166783,-3.204494 7.064573,-1.401758 0.897797,1.80275 -2.626074,3.633887 -5.268989,5.007245 z"
+     inkscape:connector-curvature="0"
+     style="fill:#3b3b3b;fill-opacity:1;fill-rule:nonzero;stroke:none" />
+  <g
+     id="g59">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path61" />
+  </g>
+</svg>


### PR DESCRIPTION
Fixes https://github.com/numixproject/numix-icon-theme-circle/issues/2076.

![pogo](https://cloud.githubusercontent.com/assets/7164227/7658494/046f0290-fb3b-11e4-84d1-b40981dd585e.png)
