### PR TITLE
Icon for Pytrainer

### DIFF
--- a/Numix-Circle/48x48/apps/pytrainer.svg
+++ b/Numix-Circle/48x48/apps/pytrainer.svg
@@ -1,0 +1,1 @@
+sportstracker.svg

--- a/Numix-Circle/48x48/apps/pytrainer.svg
+++ b/Numix-Circle/48x48/apps/pytrainer.svg
@@ -1,1 +1,260 @@
-sportstracker.svg
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="cyclograph2b.svg">
+  <metadata
+     id="metadata61">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="718"
+     id="namedview59"
+     showgrid="false"
+     inkscape:zoom="1"
+     inkscape:cx="26.672701"
+     inkscape:cy="22.610986"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4200" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4184">
+      <stop
+         style="stop-color:#ffcf7f;stop-opacity:1;"
+         offset="0"
+         id="stop4186" />
+      <stop
+         style="stop-color:#ffd793;stop-opacity:1"
+         offset="1"
+         id="stop4188" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4184"
+       id="linearGradient4190"
+       x1="1"
+       y1="24"
+       x2="47"
+       y2="24"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       opacity="0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       opacity="0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       opacity="0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill:url(#linearGradient4190);fill-opacity:1"
+     transform="matrix(0,-1,1,0,0,48)">
+    <path
+       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
+       id="path31"
+       style="fill:url(#linearGradient4190);fill-opacity:1"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     id="g33" />
+  <g
+     id="g55">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       opacity="0.1"
+       id="path57" />
+  </g>
+  <g
+     transform="translate(6.2488139e-4,5.5637006e-7)"
+     id="g4407" />
+  <path
+     style="fill:#000000;fill-opacity:0.09803922"
+     d="M 25.256334,10.001909 A 15,15 0 0 0 24.348131,10.013628 15,15 0 0 0 10.008287,25.498003 15,15 0 0 0 25.344225,39.99605 15,15 0 0 0 39.998522,24.810503 l -0.01953,-0.617188 A 15,15 0 0 0 25.256334,10.001909 Z m -0.820312,2.009766 a 13,13 0 0 1 0.564453,0.0039 l 0,10.6875 a 2.3,2.3 0 0 0 -0.09961,0 2.3,2.3 0 0 0 -0.07031,0.0059 l -5.4375,-9.419922 a 13,13 0 0 1 5.042969,-1.277343 z m 1.564453,0.03711 a 13,13 0 0 1 5.492188,1.705078 l -5.34375,9.25586 a 2.3,2.3 0 0 0 -0.148438,-0.08008 l 0,-10.88086 z m -7.494141,1.701171 5.345703,9.259766 a 2.3,2.3 0 0 0 -0.144531,0.08984 l -9.419922,-5.4375 a 13,13 0 0 1 4.21875,-3.912106 z m 13.832032,0.537109 a 13,13 0 0 1 3.916015,4.216797 l -9.263672,5.347656 a 2.3,2.3 0 0 0 -0.08984,-0.144531 l 5.4375,-9.419922 z m -18.582032,4.220703 9.25586,5.34375 a 2.3,2.3 0 0 0 -0.08203,0.148438 l -10.884766,0 a 13,13 0 0 1 1.710937,-5.492188 z m 22.957032,0.884766 a 13,13 0 0 1 1.267578,4.908203 l 0.01758,0.535157 a 13,13 0 0 1 -0.0059,0.164062 l -10.69336,0 a 2.3,2.3 0 0 0 0.002,-0.0293 l -0.0039,-0.09375 a 2.3,2.3 0 0 0 -0.0039,-0.04687 l 9.419922,-5.4375 z m -24.697266,5.607422 10.6875,0 a 2.3,2.3 0 0 0 -0.002,0.07617 2.3,2.3 0 0 0 0.0059,0.09375 l -9.416015,5.435547 a 13,13 0 0 1 -1.283198,-5.173826 13,13 0 0 1 0.0078,-0.431641 z m 15.052734,1 10.886719,0 a 13,13 0 0 1 -1.708984,5.492188 l -9.25586,-5.34375 a 2.3,2.3 0 0 0 0.07813,-0.148438 z m -4.058593,0.148438 a 2.3,2.3 0 0 0 0.08984,0.146484 L 17.660628,35.7148 a 13,13 0 0 1 -3.90625,-4.222656 l 9.25586,-5.34375 z m 3.283203,0.751953 9.425781,5.441406 a 13,13 0 0 1 -4.226562,3.902344 l -5.34375,-9.253907 a 2.3,2.3 0 0 0 0.144531,-0.08984 z m -2.441407,0.08984 a 2.3,2.3 0 0 0 0.148438,0.07813 l 0,10.892579 a 13,13 0 0 1 -5.490234,-1.716797 l 5.341796,-9.253907 z m 1.31836,0.302735 5.4375,9.417969 a 13,13 0 0 1 -5.310547,1.285156 13,13 0 0 1 -0.296875,-0.0078 l 0,-10.691406 a 2.3,2.3 0 0 0 0.05273,0.002 2.3,2.3 0 0 0 0.117188,-0.0059 z"
+     id="rect4299"
+     inkscape:connector-curvature="0" />
+  <g
+     id="g4362">
+    <rect
+       transform="matrix(0,1,-1,0,0,0)"
+       ry="1.38778e-16"
+       rx="1.38778e-16"
+       y="-22"
+       x="23"
+       height="12"
+       width="1"
+       id="rect4260"
+       style="fill:#646464;fill-opacity:1" />
+    <g
+       id="g4347">
+      <rect
+         style="fill:#646464;fill-opacity:1"
+         id="rect4246"
+         width="1"
+         height="12"
+         x="24"
+         y="10"
+         rx="1.38778e-16"
+         ry="1.38778e-16" />
+      <rect
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="-5.2153902"
+         x="32.784611"
+         height="12"
+         width="1"
+         id="rect4250"
+         style="fill:#646464;fill-opacity:1"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,0,0)" />
+      <rect
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="26"
+         x="23"
+         height="12"
+         width="1"
+         id="rect4248"
+         style="fill:#646464;fill-opacity:1" />
+      <rect
+         transform="matrix(0.5,0.8660254,-0.8660254,0.5,0,0)"
+         style="fill:#646464;fill-opacity:1"
+         id="rect4254"
+         width="1"
+         height="12"
+         x="32.784611"
+         y="-22.784609"
+         rx="1.38778e-16"
+         ry="1.38778e-16" />
+      <rect
+         style="fill:#646464;fill-opacity:1"
+         id="rect4252"
+         width="1"
+         height="12"
+         x="31.784609"
+         y="10.78461"
+         rx="1.38778e-16"
+         ry="1.38778e-16"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,0,0)" />
+      <rect
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="-38"
+         x="24.000002"
+         height="12"
+         width="1"
+         id="rect4258"
+         style="fill:#646464;fill-opacity:1"
+         transform="matrix(0,1,-1,0,0,0)" />
+      <rect
+         transform="matrix(0.5,0.8660254,-0.8660254,0.5,0,0)"
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="-6.7846098"
+         x="31.784609"
+         height="12"
+         width="1"
+         id="rect4256"
+         style="fill:#646464;fill-opacity:1" />
+      <rect
+         transform="matrix(-0.5,0.8660254,-0.8660254,-0.5,0,0)"
+         style="fill:#646464;fill-opacity:1"
+         id="rect4262"
+         width="1"
+         height="12"
+         x="8.7846117"
+         y="-46.784611"
+         rx="1.38778e-16"
+         ry="1.38778e-16" />
+      <rect
+         transform="matrix(-0.5,0.8660254,-0.8660254,-0.5,0,0)"
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="-30.784611"
+         x="7.7846098"
+         height="12"
+         width="1"
+         id="rect4264"
+         style="fill:#646464;fill-opacity:1" />
+      <rect
+         ry="1.38778e-16"
+         rx="1.38778e-16"
+         y="-46.784611"
+         x="-8.7846079"
+         height="12"
+         width="1"
+         id="rect4266"
+         style="fill:#646464;fill-opacity:1"
+         transform="matrix(-0.8660254,0.5,-0.5,-0.8660254,0,0)" />
+      <rect
+         style="fill:#646464;fill-opacity:1"
+         id="rect4268"
+         width="1"
+         height="12"
+         x="-9.7846098"
+         y="-30.784611"
+         rx="1.38778e-16"
+         ry="1.38778e-16"
+         transform="matrix(-0.8660254,0.5,-0.5,-0.8660254,0,0)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#333333;fill-opacity:1"
+         d="M 23.348131,9.0136282 A 15,15 0 0 0 9.0082872,24.498003 15,15 0 0 0 24.344225,38.99605 15,15 0 0 0 38.998522,23.810503 l -0.01953,-0.617188 A 15,15 0 0 0 23.348131,9.0136282 Z m 0.08789,1.9980468 a 13,13 0 0 1 13.544922,12.289062 l 0.01758,0.535157 A 13,13 0 0 1 24.29735,36.99605 13,13 0 0 1 11.008287,24.431597 13,13 0 0 1 23.436022,11.011675 Z"
+         id="path4773" />
+      <path
+         style="fill:#333333;fill-opacity:1"
+         id="path4792"
+         sodipodi:type="arc"
+         sodipodi:cx="24"
+         sodipodi:cy="24"
+         sodipodi:rx="2.3"
+         sodipodi:ry="2.3"
+         sodipodi:start="6.270584"
+         sodipodi:end="6.2294117"
+         sodipodi:open="true"
+         d="m 26.299817,23.971018 a 2.3,2.3 0 0 1 -2.247165,2.328379 2.3,2.3 0 0 1 -2.351385,-2.22308 2.3,2.3 0 0 1 2.198759,-2.374143 2.3,2.3 0 0 1 2.396649,2.174206" />
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
Fixes #2126

Symlink to [sportstracker.svg](https://github.com/numixproject/numix-icon-theme-circle/blob/master/Numix-Circle/48x48/apps/sportstracker.svg)

Alt:
![pytrainer](https://cloud.githubusercontent.com/assets/7050624/7670303/e4a42556-fc9f-11e4-8f23-69d993945c2c.png)
