### PR TITLE
Symlink in glogg

### DIFF
--- a/Numix-Circle/48x48/apps/glogg.svg
+++ b/Numix-Circle/48x48/apps/glogg.svg
@@ -1,0 +1,1 @@
+gpk-log.svg


### PR DESCRIPTION
Using the icon line from the repo, see #2302.

Symlink to ``gpk-log.svg`` as the ``logview.svg`` design is used quite often already.