### PR TITLE
Removes weather-clear.svg from circle

### DIFF
--- a/Numix-Circle/48x48/apps/weather-clear.svg
+++ b/Numix-Circle/48x48/apps/weather-clear.svg
@@ -1,1 +1,0 @@
-gnome-weather.svg


### PR DESCRIPTION
Indicator-weather uses this icon to display the weather condictions in the panel.If this icon (which is clearly a status icon is present in circle) the circular icon is used instead of the status icon -> Remove it, and blame the program that uses an status icon as app icon