### PR TITLE
Symlink for Merkaartor

### DIFF
--- a/Numix-Circle/48x48/apps/merkaartor.svg
+++ b/Numix-Circle/48x48/apps/merkaartor.svg
@@ -1,0 +1,1 @@
+qgis.svg


### PR DESCRIPTION
An Open Street Map editor
http://wiki.openstreetmap.org/wiki/Merkaartor

**Original icon:**
Icon=merkaartor
![merkaartor](https://cloud.githubusercontent.com/assets/7050624/9290058/04d0c7e6-4384-11e5-9eac-8f660ffe90dc.png)
