### PR TITLE
Brackets alignment fix

### DIFF
--- a/Numix-Circle/48x48/apps/brackets.svg
+++ b/Numix-Circle/48x48/apps/brackets.svg
@@ -40,8 +40,8 @@
    <!-- color: #27a6dc -->
    <g>
     <path d="m 24,9 0.004,0 C 32.285,9 39,15.715 39,24 l 0,0.004 C 39,32.285 32.285,39 24.004,39 L 24,39 C 15.715,39 9,32.285 9,24.004 L 9,24 C 9,15.715 15.715,9 24,9 m 0,0" style="fill:#f9f9f9;fill-opacity:1;stroke:none;fill-rule:evenodd"/>
-    <path d="m 14 16 0 16 8 0 0 -3 -5 0 0 -10 5 0 0 -3 m -8 0" style="fill:#535353;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
-    <path d="m 34.01 16 0 16 -9 0 0 -3 6 0 0 -10 -6 0 0 -3 m 9 0" style="fill:#535353;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+    <path d="m 15 16 0 16 8 0 0 -3 -5 0 0 -10 5 0 0 -3" style="fill:#535353;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
+    <path d="m 33.01 16 0 16 -8.01 0 0 -3 5.01 0 0 -10 -5.01 0 0 -3" style="fill:#535353;fill-opacity:1;stroke:none;fill-rule:nonzero"/>
    </g>
   </g>
  </g>


### PR DESCRIPTION
The brackets weren't equally wide.

Before:
![brackets-old](https://cloud.githubusercontent.com/assets/7050624/9428980/17b96a28-49c1-11e5-8199-d19b50d76ef1.png)

After:
![brackets](https://cloud.githubusercontent.com/assets/7050624/9428981/1d6ef2d0-49c1-11e5-9fd4-c4a7760fe8d9.png)

Or better this way or with a shadow?
![brackets0](https://cloud.githubusercontent.com/assets/7050624/9428985/34a97218-49c1-11e5-9825-37e1259e5e1b.png)
![brackets-shadow](https://cloud.githubusercontent.com/assets/7050624/9428986/34abf11e-49c1-11e5-900a-c2c283eaa19d.png)
![brackets0-shadow](https://cloud.githubusercontent.com/assets/7050624/9428987/38aff332-49c1-11e5-92ec-63a85e58baa5.png)
