### PR TITLE
Icon for GNOME Internet Radio Locator. Fixes #2501

### DIFF
--- a/Numix-Circle/48x48/apps/girl.svg
+++ b/Numix-Circle/48x48/apps/girl.svg
@@ -5,16 +5,14 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
    id="svg3899"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="girl.svg"
-   inkscape:export-filename="/home/cjohnson/Pictures/girl.png"
-   inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   sodipodi:docname="girl.svg">
   <metadata
      id="metadata3960">
     <rdf:RDF>
@@ -43,9 +41,9 @@
      inkscape:object-nodes="true"
      inkscape:snap-smooth-nodes="true"
      showguides="false"
-     inkscape:zoom="1"
+     inkscape:zoom="5.6568542"
      inkscape:cx="23.545455"
-     inkscape:cy="27.012462"
+     inkscape:cy="23.476928"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -56,6 +54,18 @@
   </sodipodi:namedview>
   <defs
      id="defs3901">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4418">
+      <stop
+         style="stop-color:#e1dfbb;stop-opacity:1"
+         offset="0"
+         id="stop4420" />
+      <stop
+         style="stop-color:#edecd6;stop-opacity:1"
+         offset="1"
+         id="stop4422" />
+    </linearGradient>
     <linearGradient
        id="linearGradient3764"
        x1="1"
@@ -94,6 +104,15 @@
            id="path3916" />
       </g>
     </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4418"
+       id="linearGradient4424"
+       x1="1"
+       y1="47"
+       x2="1"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <g
      id="g3918">
@@ -114,7 +133,7 @@
      id="g3926">
     <path
        d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
-       style="fill:url(#linearGradient3764);fill-opacity:1"
+       style="fill:url(#linearGradient4424);fill-opacity:1"
        id="path3928" />
   </g>
   <g
@@ -176,7 +195,7 @@
        inkscape:connector-curvature="0"
        id="rect3980"
        d="m 31,10.951172 0,1.003906 C 33,11.999998 35,13 36,14.5 L 37,14 C 36,12 34,11 31,10.951172 Z M 31,14 l 0,1 c 1.304543,0.0018 2.432506,0.504847 3.179688,1.574219 L 35,16 c -0.934696,-1.336724 -2.3689,-1.998739 -4,-2 z m -1,3 c -0.554,0 -1,0.446 -1,1 l 0,2 -5.308594,0 L 13,20 c -1,0 -2,1 -2,2 l 0,10 c 0,1 1,2 2,2 L 23.691406,34 35,34 c 1,0 2,-1 2,-2 l 0,-10 c 0,-1 -1,-2 -2,-2 l -2,0 0,-2 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 z m 0.5,1 1,0 c 0.277,0 0.5,0.223 0.5,0.5 l 0,1.5 -2,0 0,-1.5 C 30,18.223 30.223,18 30.5,18 Z M 14.691406,22 22,22 c 0.846154,0 1.691406,0.713449 1.691406,1.427734 l 0,7.144532 C 23.691406,31.286551 22.846154,32 22,32 l -7.308594,0 C 14.585637,32 14.479092,31.98965 14.375,31.96875 13.646356,31.822426 13,31.197265 13,30.572266 l 0,-7.144532 C 13,22.713449 13.845252,22 14.691406,22 Z m 11,0 7.617188,0 C 34.154748,22 35,22.713449 35,23.427734 l 0,7.144532 C 35,31.286551 34.154748,32 33.308594,32 l -7.617188,0 0,-10 z M 28.5,23 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,24 30,23.777 30,23.5 30,23.223 29.777,23 29.5,23 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,24 33,23.777 33,23.5 33,23.223 32.777,23 32.5,23 l -1,0 z M 18,24 c -1.656854,0 -3,1.343146 -3,3 0,1.656854 1.343146,3 3,3 1.656854,0 3,-1.343146 3,-3 0,-1.656854 -1.343146,-3 -3,-3 z m 10.5,1 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,26 30,25.777 30,25.5 30,25.223 29.777,25 29.5,25 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,26 33,25.777 33,25.5 33,25.223 32.777,25 32.5,25 l -1,0 z M 18,25.875 c 0.62132,0 1.125,0.50368 1.125,1.125 0,0.62132 -0.50368,1.125 -1.125,1.125 -0.62132,0 -1.125,-0.50368 -1.125,-1.125 0,-0.62132 0.50368,-1.125 1.125,-1.125 z M 28.5,27 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,28 30,27.777 30,27.5 30,27.223 29.777,27 29.5,27 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,28 33,27.777 33,27.5 33,27.223 32.777,27 32.5,27 l -1,0 z m 1.5,2 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m 0.482422,0.25 c 0.0059,-2.06e-4 0.01172,-2.06e-4 0.01758,0 0.138071,0 0.25,0.111929 0.25,0.25 0,0.138071 -0.111929,0.25 -0.25,0.25 -0.138071,0 -0.25,-0.111929 -0.25,-0.25 -3.25e-4,-0.131488 0.101259,-0.240755 0.232422,-0.25 z"
-       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#666666;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
   </g>
   <g
      id="g4882"

--- a/Numix-Circle/48x48/apps/girl.svg
+++ b/Numix-Circle/48x48/apps/girl.svg
@@ -1,0 +1,184 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg3899"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="girl.svg"
+   inkscape:export-filename="/home/cjohnson/Pictures/girl.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <metadata
+     id="metadata3960">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="713"
+     id="namedview3958"
+     showgrid="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     showguides="false"
+     inkscape:zoom="1"
+     inkscape:cx="23.545455"
+     inkscape:cy="27.012462"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg3899">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3962" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3901">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#e1e1e1;stop-opacity:1"
+         id="stop3904" />
+      <stop
+         offset="1"
+         style="stop-color:#ebebeb;stop-opacity:1"
+         id="stop3906" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-130176957">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3909">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path3911" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-136170233">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g3914">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path3916" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g3918">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path3920" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path3922" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path3924" />
+  </g>
+  <g
+     id="g3926">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:url(#linearGradient3764);fill-opacity:1"
+       id="path3928" />
+  </g>
+  <g
+     id="g3930">
+    <g
+       style="clip-path:url(#clipPath-130176957)"
+       id="g3932"
+       clip-path="url(#clipPath-130176957)">
+      <g
+         transform="translate(1,1)"
+         id="g3934">
+        <g
+           style="opacity:0.1"
+           id="g3936">
+          <!-- color: #ebebeb -->
+          <g
+             id="g3938" />
+        </g>
+      </g>
+    </g>
+  </g>
+  <g
+     transform="translate(1.7850532e-6,0)"
+     id="g3942">
+    <g
+       style="clip-path:url(#clipPath-136170233)"
+       id="g3944"
+       clip-path="url(#clipPath-136170233)">
+      <!-- color: #ebebeb -->
+      <g
+         id="g3946" />
+    </g>
+  </g>
+  <g
+     id="g3954">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path3956" />
+  </g>
+  <circle
+     style="opacity:0.1;fill:#000000;fill-opacity:1"
+     id="path4873"
+     cx="93"
+     cy="-48"
+     r="1" />
+  <g
+     id="g4878">
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="m 32,11.951172 0,1.003906 C 34,12.999998 36,14 37,15.5 L 38,15 C 37,13 35,12 32,11.951172 Z M 32,15 l 0,1 c 1.304543,0.0018 2.432506,0.504847 3.179688,1.574219 L 36,17 c -0.934696,-1.336724 -2.3689,-1.998739 -4,-2 z m -1,3 c -0.554,0 -1,0.446 -1,1 l 0,2 -5.308594,0 L 14,21 c -1,0 -2,1 -2,2 l 0,10 c 0,1 1,2 2,2 L 24.691406,35 36,35 c 1,0 2,-1 2,-2 l 0,-10 c 0,-1 -1,-2 -2,-2 l -2,0 0,-2 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 z m 0.5,1 1,0 c 0.277,0 0.5,0.223 0.5,0.5 l 0,1.5 -2,0 0,-1.5 C 31,19.223 31.223,19 31.5,19 Z M 15.691406,23 23,23 c 0.846154,0 1.691406,0.713449 1.691406,1.427734 l 0,7.144532 C 24.691406,32.286551 23.846154,33 23,33 l -7.308594,0 C 15.585637,33 15.479092,32.98965 15.375,32.96875 14.646356,32.822426 14,32.197265 14,31.572266 l 0,-7.144532 C 14,23.713449 14.845252,23 15.691406,23 Z m 11,0 7.617188,0 C 35.154748,23 36,23.713449 36,24.427734 l 0,7.144532 C 36,32.286551 35.154748,33 34.308594,33 l -7.617188,0 0,-10 z M 29.5,24 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 30.777,25 31,24.777 31,24.5 31,24.223 30.777,24 30.5,24 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 33.777,25 34,24.777 34,24.5 34,24.223 33.777,24 33.5,24 l -1,0 z M 19,25 c -1.656854,0 -3,1.343146 -3,3 0,1.656854 1.343146,3 3,3 1.656854,0 3,-1.343146 3,-3 0,-1.656854 -1.343146,-3 -3,-3 z m 10.5,1 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 30.777,27 31,26.777 31,26.5 31,26.223 30.777,26 30.5,26 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 33.777,27 34,26.777 34,26.5 34,26.223 33.777,26 33.5,26 l -1,0 z M 19,26.875 c 0.62132,0 1.125,0.50368 1.125,1.125 0,0.62132 -0.50368,1.125 -1.125,1.125 -0.62132,0 -1.125,-0.50368 -1.125,-1.125 0,-0.62132 0.50368,-1.125 1.125,-1.125 z M 29.5,28 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 30.777,29 31,28.777 31,28.5 31,28.223 30.777,28 30.5,28 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 33.777,29 34,28.777 34,28.5 34,28.223 33.777,28 33.5,28 l -1,0 z m 1.5,2 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m 0.482422,0.25 c 0.0059,-2.06e-4 0.01172,-2.06e-4 0.01758,0 0.138071,0 0.25,0.111929 0.25,0.25 0,0.138071 -0.111929,0.25 -0.25,0.25 -0.138071,0 -0.25,-0.111929 -0.25,-0.25 -3.25e-4,-0.131488 0.101259,-0.240755 0.232422,-0.25 z"
+       id="path4891"
+       inkscape:connector-curvature="0" />
+    <path
+       id="path4875"
+       d="M 19.125,27 A 1.125,1.125 0 0 1 18,28.125 1.125,1.125 0 0 1 16.875,27 1.125,1.125 0 0 1 18,25.875 1.125,1.125 0 0 1 19.125,27 Z"
+       style="opacity:1;fill:#f9f9f9;fill-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="rect3980"
+       d="m 31,10.951172 0,1.003906 C 33,11.999998 35,13 36,14.5 L 37,14 C 36,12 34,11 31,10.951172 Z M 31,14 l 0,1 c 1.304543,0.0018 2.432506,0.504847 3.179688,1.574219 L 35,16 c -0.934696,-1.336724 -2.3689,-1.998739 -4,-2 z m -1,3 c -0.554,0 -1,0.446 -1,1 l 0,2 -5.308594,0 L 13,20 c -1,0 -2,1 -2,2 l 0,10 c 0,1 1,2 2,2 L 23.691406,34 35,34 c 1,0 2,-1 2,-2 l 0,-10 c 0,-1 -1,-2 -2,-2 l -2,0 0,-2 c 0,-0.554 -0.446,-1 -1,-1 l -2,0 z m 0.5,1 1,0 c 0.277,0 0.5,0.223 0.5,0.5 l 0,1.5 -2,0 0,-1.5 C 30,18.223 30.223,18 30.5,18 Z M 14.691406,22 22,22 c 0.846154,0 1.691406,0.713449 1.691406,1.427734 l 0,7.144532 C 23.691406,31.286551 22.846154,32 22,32 l -7.308594,0 C 14.585637,32 14.479092,31.98965 14.375,31.96875 13.646356,31.822426 13,31.197265 13,30.572266 l 0,-7.144532 C 13,22.713449 13.845252,22 14.691406,22 Z m 11,0 7.617188,0 C 34.154748,22 35,22.713449 35,23.427734 l 0,7.144532 C 35,31.286551 34.154748,32 33.308594,32 l -7.617188,0 0,-10 z M 28.5,23 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,24 30,23.777 30,23.5 30,23.223 29.777,23 29.5,23 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,24 33,23.777 33,23.5 33,23.223 32.777,23 32.5,23 l -1,0 z M 18,24 c -1.656854,0 -3,1.343146 -3,3 0,1.656854 1.343146,3 3,3 1.656854,0 3,-1.343146 3,-3 0,-1.656854 -1.343146,-3 -3,-3 z m 10.5,1 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,26 30,25.777 30,25.5 30,25.223 29.777,25 29.5,25 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,26 33,25.777 33,25.5 33,25.223 32.777,25 32.5,25 l -1,0 z M 18,25.875 c 0.62132,0 1.125,0.50368 1.125,1.125 0,0.62132 -0.50368,1.125 -1.125,1.125 -0.62132,0 -1.125,-0.50368 -1.125,-1.125 0,-0.62132 0.50368,-1.125 1.125,-1.125 z M 28.5,27 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 29.777,28 30,27.777 30,27.5 30,27.223 29.777,27 29.5,27 l -1,0 z m 3,0 c -0.277,0 -0.5,0.223 -0.5,0.5 0,0.277 0.223,0.5 0.5,0.5 l 1,0 C 32.777,28 33,27.777 33,27.5 33,27.223 32.777,27 32.5,27 l -1,0 z m 1.5,2 c -0.552285,0 -1,0.447715 -1,1 0,0.552285 0.447715,1 1,1 0.552285,0 1,-0.447715 1,-1 0,-0.552285 -0.447715,-1 -1,-1 z m 0.482422,0.25 c 0.0059,-2.06e-4 0.01172,-2.06e-4 0.01758,0 0.138071,0 0.25,0.111929 0.25,0.25 0,0.138071 -0.111929,0.25 -0.25,0.25 -0.138071,0 -0.25,-0.111929 -0.25,-0.25 -3.25e-4,-0.131488 0.101259,-0.240755 0.232422,-0.25 z"
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#4d4d4d;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+  </g>
+  <g
+     id="g4882"
+     style="fill:#000000;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
Original Icon:
![8ea1ff90-4b58-11e5-8b2b-f9473da8c568](https://cloud.githubusercontent.com/assets/5553828/9529856/a489abaa-4cca-11e5-8550-0bc5bdb1f5c6.png)
Pushed Icon:
![girl](https://cloud.githubusercontent.com/assets/5553828/9529864/b5619f96-4cca-11e5-8308-4424439e463c.png)
