### PR TITLE
Icon for GNOME To Do

### DIFF
--- a/Numix-Circle/48x48/apps/gnome-todo.svg
+++ b/Numix-Circle/48x48/apps/gnome-todo.svg
@@ -1,0 +1,53 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <defs>
+  <linearGradient id="linearGradient3845" y1="47" x2="0" y2="1" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#4678b0;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#5082ba;stop-opacity:1"/>
+  </linearGradient>
+  <clipPath id="clipPath-379022256">
+   <g transform="translate(0,-1004.3622)">
+    <path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" style="fill:#1890d0"/>
+   </g>
+  </clipPath>
+  <clipPath id="clipPath-384196710">
+   <g transform="translate(0,-1004.3622)">
+    <path d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z" transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)" style="fill:#1890d0"/>
+   </g>
+  </clipPath>
+  <linearGradient id="linear0" gradientUnits="userSpaceOnUse" x1="3.669" x2="10.442" gradientTransform="matrix(3.543307,0,0,3.543307,-1,0)">
+   <stop style="stop-color:#e2f4fb;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#f9f9f9;stop-opacity:1"/>
+  </linearGradient>
+ </defs>
+ <g>
+  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
+  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
+  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
+ </g>
+ <g>
+  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3845);fill-opacity:1"/>
+ </g>
+ <g>
+  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
+ </g>
+ <g>
+  <g style="clip-path:url(#clipPath-379022256)">
+   <g transform="translate(1,1)">
+    <g style="opacity:0.1">
+     <!-- color: #5dba7c -->
+     <g>
+      <path d="m 12 26 8 8 16 -17 -3 -3 -13 14 -5 -5 m -3 3" style="fill:#000;stroke:none;fill-rule:evenodd"/>
+     </g>
+    </g>
+   </g>
+  </g>
+ </g>
+ <g>
+  <g style="clip-path:url(#clipPath-384196710)">
+   <!-- color: #5dba7c -->
+   <g>
+    <path d="m 12 26 8 8 16 -17 -3 -3 -13 14 -5 -5 m -3 3" style="fill:url(#linear0);stroke:none;fill-rule:evenodd"/>
+   </g>
+  </g>
+ </g>
+</svg>


### PR DESCRIPTION
New app for GNOME 3.18.
https://wiki.gnome.org/Apps/Todo

**Original icon:**
Icon=gnome-todo
![gnome-todo-ori](https://cloud.githubusercontent.com/assets/7050624/9698984/f6d4d266-53cf-11e5-8e6b-ed6ab6144849.png)

It's the [Tasque](https://wiki.gnome.org/Apps/Tasque) icon recoloured so that's what I did.

![gnome-todo](https://cloud.githubusercontent.com/assets/7050624/9698989/23fa8376-53d0-11e5-865c-859d2273527f.png)

