### PR TITLE
Icon for QWinFF, fixes for WinFF

### DIFF
--- a/Numix-Circle/48x48/apps/qwinff.svg
+++ b/Numix-Circle/48x48/apps/qwinff.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
  <defs>
   <linearGradient id="linearGradient4174" y1="47" x2="0" y2="1" gradientUnits="userSpaceOnUse">
-   <stop style="stop-color:#5097dc;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#61a0df;stop-opacity:1"/>
+   <stop style="stop-color:#7bb432;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#86c436;stop-opacity:1"/>
   </linearGradient>
   <linearGradient id="linearGradient4182" y1="47" x2="0" y2="1" gradientUnits="userSpaceOnUse">
-   <stop style="stop-color:#67a6e3;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#78afe6;stop-opacity:1"/>
+   <stop style="stop-color:#8ec63e;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#97cc4c;stop-opacity:1"/>
   </linearGradient>
  </defs>
  <g>


### PR DESCRIPTION
FFmpeg media file converting GUI
http://qwinff.github.io/

**Original icon:**
Icon=qwinff
![qwinff](https://cloud.githubusercontent.com/assets/7050624/9705984/9733ce4e-54d7-11e5-8336-e49e3a69273d.png)

**Pushed icon:**
![qwinff-numix](https://cloud.githubusercontent.com/assets/7050624/9705987/a0d2691a-54d7-11e5-92ee-79e921c21f61.png)

Added missing gradient to *winff.svg*.

