### PR TITLE
Unity Editor fix and Unity Monodevelop new icon

### DIFF
--- a/Numix-Circle/48x48/apps/unity-editor-icon.svg
+++ b/Numix-Circle/48x48/apps/unity-editor-icon.svg
@@ -34,16 +34,16 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="411"
-     inkscape:window-height="980"
+     inkscape:window-width="1366"
+     inkscape:window-height="722"
      id="namedview85"
-     showgrid="true"
-     inkscape:zoom="1.7383042"
-     inkscape:cx="45.284721"
-     inkscape:cy="-13.418725"
-     inkscape:window-x="859"
-     inkscape:window-y="34"
-     inkscape:window-maximized="0"
+     showgrid="false"
+     inkscape:zoom="12.255319"
+     inkscape:cx="23.805424"
+     inkscape:cy="23.5"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
      inkscape:current-layer="svg2">
     <inkscape:grid
        type="xygrid"
@@ -61,21 +61,21 @@
        y2="0"
        spreadMethod="pad">
       <stop
-         style="stop-color:#222c37;stop-opacity:1"
+         style="stop-color:#2a3644;stop-opacity:1"
          id="stop7" />
       <stop
          offset="1"
-         style="stop-color:#222c37;stop-opacity:1"
+         style="stop-color:#222c38;stop-opacity:1"
          id="stop9" />
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3764"
        id="linearGradient4244"
-       x1="1"
-       y1="24"
-       x2="47"
-       y2="24"
+       x1="24"
+       y1="1"
+       x2="24"
+       y2="47"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <path
@@ -96,7 +96,7 @@
   <path
      inkscape:connector-curvature="0"
      id="path39"
-     style="fill:url(#linearGradient4244);fill-opacity:1.0"
+     style="fill:url(#linearGradient4244);fill-opacity:1"
      d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z" />
   <g
      id="g81">

--- a/Numix-Circle/48x48/apps/unity-monodevelop.svg
+++ b/Numix-Circle/48x48/apps/unity-monodevelop.svg
@@ -1,0 +1,190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="unity-monodevelop.svg"
+   inkscape:export-filename="/home/ismael/Imágenes/icons.png"
+   inkscape:export-xdpi="245"
+   inkscape:export-ydpi="245">
+  <metadata
+     id="metadata63">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1366"
+     inkscape:window-height="722"
+     id="namedview61"
+     showgrid="false"
+     inkscape:zoom="12.255319"
+     inkscape:cx="24.499"
+     inkscape:cy="23.5"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4191" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#2a3644;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#222c38;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-902001221">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-911982837">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3764"
+       id="linearGradient4223"
+       x1="24"
+       y1="1"
+       x2="24"
+       y2="47"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill-opacity:1;fill:url(#linearGradient4223)">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:url(#linearGradient4223);fill-opacity:1"
+       id="path31" />
+  </g>
+  <g
+     id="g57">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path59" />
+  </g>
+  <path
+     d="m 25.907878,24.000855 5.201813,-9.065537 2.513662,9.065537 -2.513662,9.063461 -5.201813,-9.063461 z m -2.535409,1.472181 5.202654,9.064205 -9.060818,-2.342787 -6.545877,-6.721418 10.404041,0 z m 5.201443,-12.011116 -5.201443,9.06553 -10.404041,0 6.545877,-6.721775 9.059607,-2.343755 z M 35.999994,20.915762 32.826465,9.000002 20.981328,12.19339 19.227937,15.304708 15.669873,15.278968 7,24.001696 l 8.669873,8.720659 4.26e-4,0 3.556433,-0.02656 1.755925,3.111302 L 32.826473,39 36,27.086409 34.197795,24.000852 36,20.915759"
+     style="opacity:0.25;fill:#e8eef2;fill-opacity:1;fill-rule:nonzero;stroke:none"
+     id="path24"
+     inkscape:connector-curvature="0" />
+  <g
+     transform="matrix(0.92290665,0,0,0.92290665,2.8495356,2.6800702)"
+     id="g4225"
+     style="fill:#000000;stroke:#000000;opacity:0.1">
+    <g
+       clip-path="url(#clipPath-911982837)"
+       id="g4227"
+       style="fill:#000000;stroke:#000000">
+      <!-- color: #6e90bb -->
+      <g
+         id="g4229"
+         style="fill:#000000;stroke:#000000">
+        <path
+           inkscape:connector-curvature="0"
+           id="path4231"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.48899999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           transform="matrix(2.385496,0,0,2.368665,-25.777381,-663.45245)"
+           d="m 16.889,294.2 c -0.521,-1.265 -1.213,-2.378 -1.228,-4.441 -0.016,-2.132 1.813,-3.513 3.259,-3.513 1.749,0 3.29,1.478 3.37,2.7 0.074,1.105 -0.319,2.711 -2.348,2.701 -0.968,-0.008 -1.975,-0.849 -1.98,-2.104 -0.008,-1.351 1.687,-1.484 2.116,-1.141 0.165,0.135 0.16,0.399 0.013,0.351 -0.912,-0.297 -1.477,0.29 -1.433,0.871 0.056,0.793 0.526,1.263 1.366,1.301 1.213,0.059 1.552,-1.12 1.521,-1.6 -0.039,-0.582 -0.545,-1.779 -2.124,-1.997 -0.745,-0.104 -1.364,0.119 -1.814,0.556 -0.452,0.44 -0.706,0.892 -0.742,1.634 -0.039,0.767 0.128,1.217 0.588,2.225 0.164,0.36 0.622,1.085 0.976,1.812 l -1.539,0.642 m 0,0.003" />
+        <path
+           inkscape:connector-curvature="0"
+           id="path4233"
+           style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#000000;stroke-width:0.417;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           transform="matrix(2.385496,0,0,2.368665,-25.777381,-663.45245)"
+           d="m 24.879,286.25 c 0.522,1.263 1.215,2.376 1.23,4.441 0.016,2.132 -1.813,3.511 -3.259,3.511 -1.75,0 -3.29,-1.478 -3.37,-2.701 -0.074,-1.105 0.319,-2.711 2.348,-2.7 0.969,0.007 1.976,0.849 1.981,2.103 0.007,1.352 -1.69,1.486 -2.117,1.141 -0.165,-0.134 -0.16,-0.399 -0.015,-0.351 0.914,0.297 1.477,-0.289 1.436,-0.871 -0.057,-0.792 -0.526,-1.262 -1.367,-1.301 -1.213,-0.058 -1.552,1.121 -1.521,1.601 0.038,0.582 0.545,1.779 2.124,1.997 0.745,0.104 1.364,-0.119 1.814,-0.557 0.45,-0.439 0.706,-0.891 0.742,-1.633 0.038,-0.767 -0.129,-1.217 -0.588,-2.225 -0.164,-0.361 -0.622,-1.085 -0.978,-1.812 l 1.541,-0.643 m -0.002,0" />
+      </g>
+    </g>
+  </g>
+  <g
+     id="g47"
+     transform="matrix(0.92290665,0,0,0.92290665,1.8495356,1.6800702)">
+    <g
+       id="g49"
+       clip-path="url(#clipPath-911982837)">
+      <!-- color: #6e90bb -->
+      <g
+         id="g51">
+        <path
+           d="m 16.889,294.2 c -0.521,-1.265 -1.213,-2.378 -1.228,-4.441 -0.016,-2.132 1.813,-3.513 3.259,-3.513 1.749,0 3.29,1.478 3.37,2.7 0.074,1.105 -0.319,2.711 -2.348,2.701 -0.968,-0.008 -1.975,-0.849 -1.98,-2.104 -0.008,-1.351 1.687,-1.484 2.116,-1.141 0.165,0.135 0.16,0.399 0.013,0.351 -0.912,-0.297 -1.477,0.29 -1.433,0.871 0.056,0.793 0.526,1.263 1.366,1.301 1.213,0.059 1.552,-1.12 1.521,-1.6 -0.039,-0.582 -0.545,-1.779 -2.124,-1.997 -0.745,-0.104 -1.364,0.119 -1.814,0.556 -0.452,0.44 -0.706,0.892 -0.742,1.634 -0.039,0.767 0.128,1.217 0.588,2.225 0.164,0.36 0.622,1.085 0.976,1.812 l -1.539,0.642 m 0,0.003"
+           transform="matrix(2.385496,0,0,2.368665,-25.777381,-663.45245)"
+           style="fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#6e8db2;stroke-width:0.48899999;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           id="path53"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 24.879,286.25 c 0.522,1.263 1.215,2.376 1.23,4.441 0.016,2.132 -1.813,3.511 -3.259,3.511 -1.75,0 -3.29,-1.478 -3.37,-2.701 -0.074,-1.105 0.319,-2.711 2.348,-2.7 0.969,0.007 1.976,0.849 1.981,2.103 0.007,1.352 -1.69,1.486 -2.117,1.141 -0.165,-0.134 -0.16,-0.399 -0.015,-0.351 0.914,0.297 1.477,-0.289 1.436,-0.871 -0.057,-0.792 -0.526,-1.262 -1.367,-1.301 -1.213,-0.058 -1.552,1.121 -1.521,1.601 0.038,0.582 0.545,1.779 2.124,1.997 0.745,0.104 1.364,-0.119 1.814,-0.557 0.45,-0.439 0.706,-0.891 0.742,-1.633 0.038,-0.767 -0.129,-1.217 -0.588,-2.225 -0.164,-0.361 -0.622,-1.085 -0.978,-1.812 l 1.541,-0.643 m -0.002,0"
+           transform="matrix(2.385496,0,0,2.368665,-25.777381,-663.45245)"
+           style="fill:#a9c1e3;fill-opacity:1;fill-rule:nonzero;stroke:#6e8db2;stroke-width:0.417;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1"
+           id="path55"
+           inkscape:connector-curvature="0" />
+      </g>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
* Background gradient colour fixed in unity-editor-icon.svg ( #2505 )
* New icon: unity-monodevelop.svg

![icons](https://cloud.githubusercontent.com/assets/8478202/9837912/2d9ab16e-5a4f-11e5-9f62-368cae6d9f2a.png)
 
