### PR TITLE
Maxima X interface icon

### DIFF
--- a/Numix-Circle/48x48/apps/maxima.svg
+++ b/Numix-Circle/48x48/apps/maxima.svg
@@ -1,0 +1,1 @@
+wxmaxima.svg


### PR DESCRIPTION
Created a symlink to wxMaxima icon that already existed. These interfaces are different but we can use same icon. 

In this case it is not **hardcoded**.