### PR TITLE
KiCAD alternative icon added

### DIFF
--- a/Numix-Circle/48x48/apps/kicad2.svg
+++ b/Numix-Circle/48x48/apps/kicad2.svg
@@ -1,0 +1,257 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg4696"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="kicad.svg">
+  <metadata
+     id="metadata4757">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1839"
+     inkscape:window-height="1050"
+     id="namedview4755"
+     showgrid="false"
+     inkscape:zoom="17.31267"
+     inkscape:cx="29.749588"
+     inkscape:cy="23.5"
+     inkscape:window-x="81"
+     inkscape:window-y="30"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4696"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="false"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true" />
+  <defs
+     id="defs4698">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#575757;stop-opacity:1"
+         id="stop4701" />
+      <stop
+         offset="1"
+         style="stop-color:#616161;stop-opacity:1"
+         id="stop4703" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-453839718">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g4706">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path4708" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-462896869">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g4711">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path4713" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linearGradient10125-12">
+      <stop
+         style="stop-color: rgb(201, 156, 0); stop-opacity: 1;"
+         offset="0"
+         id="stop10127-04" />
+      <stop
+         style="stop-color: rgb(135, 105, 0); stop-opacity: 1;"
+         offset="1"
+         id="stop10129-4" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient10286-3">
+      <stop
+         id="stop10288-8"
+         offset="0"
+         style="stop-color: rgb(179, 179, 179); stop-opacity: 1;" />
+      <stop
+         id="stop10290-7"
+         offset="1"
+         style="stop-color: rgb(230, 230, 230); stop-opacity: 1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient15606-1">
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.588235;"
+         offset="0"
+         id="stop15608-0" />
+      <stop
+         style="stop-color: rgb(255, 255, 255); stop-opacity: 0.862745;"
+         offset="1"
+         id="stop15610-5" />
+    </linearGradient>
+  </defs>
+  <g
+     id="g4715">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path4717" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path4719" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path4721" />
+  </g>
+  <g
+     id="g4723"
+     style="fill:#c69900;fill-opacity:1"
+     transform="translate(-0.20216424,0.05776108)">
+    <path
+       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
+       style="fill:#c69900;fill-opacity:1"
+       id="path4725"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     style="fill:#d1d1d1;fill-opacity:1"
+     id="g7909"
+     transform="matrix(0.85605336,0,0,0.88132679,3.2525551,2.9059181)">
+    <path
+       id="path7911"
+       style="fill:#d1d1d1;fill-opacity:1"
+       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     transform="matrix(0.75442379,0,0,0.76008482,5.6916648,5.8157254)"
+     id="g8039"
+     style="fill:#e9e9e9;fill-opacity:1">
+    <path
+       inkscape:connector-curvature="0"
+       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
+       style="fill:#e9e9e9;fill-opacity:1"
+       id="path8041" />
+  </g>
+  <g
+     id="g4751">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path4753" />
+  </g>
+  <path
+     id="path303-2"
+     d="m 26.163751,39.077536 0,-6.711125 11.667944,0"
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.02158511px;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path305-2"
+     d="m 27.709638,34.363441 3.06691,0"
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.29452348px;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path307-0"
+     d="m 32.6922,34.442553 4.814817,0"
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.31523824px;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path309-5"
+     d="m 27.275919,37.918804 3.633201,0"
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.5183084px;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     id="path311-5"
+     d="m 34.107553,37.579873 2.692868,0"
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.63579941px;stroke-opacity:1"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.73609674;stroke-linecap:square;stroke-opacity:1"
+     d="m 14.544443,25.452682 0,7.095248"
+     id="path315-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:round;stroke-opacity:1"
+     d="m 18.012129,25.609751 -3.39225,3.271231"
+     id="path317-0"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:round;stroke-opacity:1"
+     d="m 18.012129,32.785118 -3.39225,-3.271231"
+     id="path319-2"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.60529697;stroke-linecap:square;stroke-opacity:1"
+     d="m 14.700322,28.960096 -6.0579479,0"
+     id="path321-8"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.56478;stroke-linecap:round;stroke-opacity:1"
+     d="m 18.012129,33.433001 0,3.847789"
+     id="path323-3"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:square;stroke-opacity:1"
+     d="m 19.783689,37.883506 -3.354936,0"
+     id="path325-8"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.60053742;stroke-linecap:round;stroke-opacity:1"
+     d="m 17.910843,25.326119 0,-5.207997"
+     id="path327-0"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.68019307;stroke-linecap:square;stroke-opacity:1"
+     d="m 19.687556,19.805145 -3.377996,0 0,-6.685742 3.377996,0 0,6.685742"
+     id="path329-4"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.67220414;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 18.717084,23.657683 7.683869,0"
+     id="path331-0"
+     inkscape:connector-curvature="0" />
+  <path
+     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.42366898;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 17.984992,8.4995907 0,4.6182013"
+     id="path333-9"
+     inkscape:connector-curvature="0" />
+  <path
+     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.76333153px;stroke-opacity:1"
+     d="m 27.979209,21.751767 7.048431,-0.04087 1.864812,1.78504 -1.847165,1.689717 -7.066078,-0.05449 0,-3.379436 z"
+     id="path361-0"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/Numix-Circle/48x48/apps/kicad2.svg
+++ b/Numix-Circle/48x48/apps/kicad2.svg
@@ -8,12 +8,12 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
-   id="svg4696"
+   id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="kicad.svg">
+   sodipodi:docname="icon_kicad.svg">
   <metadata
-     id="metadata4757">
+     id="metadata33">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
@@ -35,21 +35,20 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1839"
      inkscape:window-height="1050"
-     id="namedview4755"
+     id="namedview31"
      showgrid="false"
-     inkscape:zoom="17.31267"
-     inkscape:cx="29.749588"
-     inkscape:cy="23.5"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-to-guides="true"
+     inkscape:zoom="9.8333333"
+     inkscape:cx="21.662933"
+     inkscape:cy="19.414355"
      inkscape:window-x="81"
      inkscape:window-y="30"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg4696"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="false"
-     inkscape:snap-bbox-midpoints="true"
-     inkscape:snap-global="true" />
+     inkscape:current-layer="svg2" />
   <defs
-     id="defs4698">
+     id="defs4">
     <linearGradient
        id="linearGradient3764"
        x1="1"
@@ -57,37 +56,13 @@
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
       <stop
-         style="stop-color:#575757;stop-opacity:1"
-         id="stop4701" />
+         style="stop-color:#e51f32;stop-opacity:1"
+         id="stop7" />
       <stop
          offset="1"
-         style="stop-color:#616161;stop-opacity:1"
-         id="stop4703" />
+         style="stop-color:#e73245;stop-opacity:1"
+         id="stop9" />
     </linearGradient>
-    <clipPath
-       id="clipPath-453839718">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g4706">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           style="fill:#1890d0"
-           id="path4708" />
-      </g>
-    </clipPath>
-    <clipPath
-       id="clipPath-462896869">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g4711">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           style="fill:#1890d0"
-           id="path4713" />
-      </g>
-    </clipPath>
     <linearGradient
        id="linearGradient10125-12">
       <stop
@@ -123,135 +98,135 @@
     </linearGradient>
   </defs>
   <g
-     id="g4715">
+     id="g11">
     <path
        d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
        style="opacity:0.05"
-       id="path4717" />
+       id="path13" />
     <path
        d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
        style="opacity:0.1"
-       id="path4719" />
+       id="path15" />
     <path
        d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
        style="opacity:0.2"
-       id="path4721" />
+       id="path17" />
   </g>
   <g
-     id="g4723"
-     style="fill:#c69900;fill-opacity:1"
-     transform="translate(-0.20216424,0.05776108)">
+     id="g19"
+     style="fill:#b58c00;fill-opacity:1">
     <path
-       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
-       style="fill:#c69900;fill-opacity:1"
-       id="path4725"
-       inkscape:connector-curvature="0" />
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:#b58c00;fill-opacity:1"
+       id="path21" />
   </g>
   <g
-     style="fill:#d1d1d1;fill-opacity:1"
-     id="g7909"
-     transform="matrix(0.85605336,0,0,0.88132679,3.2525551,2.9059181)">
-    <path
-       id="path7911"
-       style="fill:#d1d1d1;fill-opacity:1"
-       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
-       inkscape:connector-curvature="0" />
-  </g>
-  <g
-     transform="matrix(0.75442379,0,0,0.76008482,5.6916648,5.8157254)"
-     id="g8039"
-     style="fill:#e9e9e9;fill-opacity:1">
-    <path
-       inkscape:connector-curvature="0"
-       d="M 24,1 C 36.703,1 47,11.297 47,24 47,36.703 36.703,47 24,47 11.297,47 1,36.703 1,24 1,11.297 11.297,1 24,1 Z"
-       style="fill:#e9e9e9;fill-opacity:1"
-       id="path8041" />
-  </g>
-  <g
-     id="g4751">
+     id="g23">
     <path
        d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
        style="opacity:0.1"
-       id="path4753" />
+       id="path25" />
   </g>
-  <path
-     id="path303-2"
-     d="m 26.163751,39.077536 0,-6.711125 11.667944,0"
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.02158511px;stroke-opacity:1"
-     inkscape:connector-curvature="0" />
-  <path
-     id="path305-2"
-     d="m 27.709638,34.363441 3.06691,0"
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.29452348px;stroke-opacity:1"
-     inkscape:connector-curvature="0" />
-  <path
-     id="path307-0"
-     d="m 32.6922,34.442553 4.814817,0"
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.31523824px;stroke-opacity:1"
-     inkscape:connector-curvature="0" />
-  <path
-     id="path309-5"
-     d="m 27.275919,37.918804 3.633201,0"
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.5183084px;stroke-opacity:1"
-     inkscape:connector-curvature="0" />
-  <path
-     id="path311-5"
-     d="m 34.107553,37.579873 2.692868,0"
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.63579941px;stroke-opacity:1"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.73609674;stroke-linecap:square;stroke-opacity:1"
-     d="m 14.544443,25.452682 0,7.095248"
-     id="path315-9"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:round;stroke-opacity:1"
-     d="m 18.012129,25.609751 -3.39225,3.271231"
-     id="path317-0"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:round;stroke-opacity:1"
-     d="m 18.012129,32.785118 -3.39225,-3.271231"
-     id="path319-2"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.60529697;stroke-linecap:square;stroke-opacity:1"
-     d="m 14.700322,28.960096 -6.0579479,0"
-     id="path321-8"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.56478;stroke-linecap:round;stroke-opacity:1"
-     d="m 18.012129,33.433001 0,3.847789"
-     id="path323-3"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.66559529;stroke-linecap:square;stroke-opacity:1"
-     d="m 19.783689,37.883506 -3.354936,0"
-     id="path325-8"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.60053742;stroke-linecap:round;stroke-opacity:1"
-     d="m 17.910843,25.326119 0,-5.207997"
-     id="path327-0"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.68019307;stroke-linecap:square;stroke-opacity:1"
-     d="m 19.687556,19.805145 -3.377996,0 0,-6.685742 3.377996,0 0,6.685742"
-     id="path329-4"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.67220414;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 18.717084,23.657683 7.683869,0"
-     id="path331-0"
-     inkscape:connector-curvature="0" />
-  <path
-     style="color:#000000;fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.42366898;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-     d="m 17.984992,8.4995907 0,4.6182013"
-     id="path333-9"
-     inkscape:connector-curvature="0" />
-  <path
-     style="fill:#000000;fill-opacity:0;stroke:#a33e03;stroke-width:1.76333153px;stroke-opacity:1"
-     d="m 27.979209,21.751767 7.048431,-0.04087 1.864812,1.78504 -1.847165,1.689717 -7.066078,-0.05449 0,-3.379436 z"
-     id="path361-0"
-     inkscape:connector-curvature="0" />
+  <circle
+     r="19.118643"
+     cy="24"
+     cx="24"
+     id="circle4540"
+     style="fill:#f8f8f8;fill-opacity:1" />
+  <circle
+     style="fill:#d5d5d5;fill-opacity:1"
+     id="path4534"
+     cx="24"
+     cy="24"
+     r="18.61017" />
+  <circle
+     style="fill:#f8f8f8;fill-opacity:1"
+     id="path4536"
+     cx="24"
+     cy="24"
+     r="17.424726" />
+  <g
+     id="g4542"
+     transform="matrix(1.4096299,0,0,1.4096299,65.205204,-4.3954569)">
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#a33e03;stroke-width:0.58063614px;stroke-opacity:1"
+       d="m -27.387324,28.175286 0,-3.724729 6.791318,0"
+       id="path303-2" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#a33e03;stroke-width:0.73576558px;stroke-opacity:1"
+       d="m -26.487542,25.558925 1.785093,0"
+       id="path305-2" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#a33e03;stroke-width:0.74753916px;stroke-opacity:1"
+       d="m -23.587446,25.602833 2.802461,0"
+       id="path307-0" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#a33e03;stroke-width:0.86295766px;stroke-opacity:1"
+       d="m -26.739988,27.53218 2.114702,0"
+       id="path309-5" />
+    <path
+       inkscape:connector-curvature="0"
+       style="fill:none;stroke:#a33e03;stroke-width:1.01523209px;stroke-opacity:1"
+       d="m -22.595541,27.554134 1.868901,0"
+       id="path311-5" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path315-9"
+       d="m -34.150333,20.613382 0,3.93792"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.9867416;stroke-linecap:square;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path317-0"
+       d="m -32.131969,20.700556 -1.974456,1.81556"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.94667083;stroke-linecap:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path319-2"
+       d="m -32.131969,24.682943 -1.974456,-1.81556"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.94667083;stroke-linecap:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path321-8"
+       d="m -34.091711,22.560025 -3.795889,0"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.94667083;stroke-linecap:square;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path323-3"
+       d="m -32.131969,25.042523 0,2.135555"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.88937062;stroke-linecap:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path325-8"
+       d="m -31.100834,27.51259 -1.952738,0"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.94667083;stroke-linecap:square;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path327-0"
+       d="m -32.190923,20.543138 0,-2.89048"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.90969408;stroke-linecap:round;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path329-4"
+       d="m -31.156788,17.478954 -1.96616,0 0,-3.710641 1.96616,0 0,3.710641"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.95496774;stroke-linecap:square;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path331-0"
+       d="m -31.721651,19.617144 4.47239,0"
+       style="color:#000000;fill:none;stroke:#a33e03;stroke-width:0.95042706;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path333-9"
+       d="m -32.147764,10.133045 0,3.508842"
+       style="color:#000000;fill:#a33e03;fill-opacity:1;stroke:#a33e03;stroke-width:0.94674802;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path361-0"
+       d="m -26.330638,18.559345 4.102533,-0.02269 1.085413,0.990712 -1.075141,0.937806 -4.112805,-0.03024 0,-1.875614 z"
+       style="fill:none;stroke:#a33e03;stroke-width:1.00222099px;stroke-opacity:1" />
+  </g>
 </svg>


### PR DESCRIPTION
Hello,

I made a new KiCAD icon, because I got used to the default one but I wanted to have one of the awesome numix-circle-theme icons. 

I'm running Ubuntu 15.04 and in my /usr/share/applications/kicad.desktop had the entry 
 Icon=icon_kicad.png (see http://askubuntu.com/questions/694627/numix-circle-theme-change-one-icon) so I did not know how to name the new icon and I can't even show my own new one to replace the kicad.svg

This is my first pull request so help and advice according to my icon is appreciated. :)

edit: I couldn't find the guidlines if there any, so please point me to it or tell me if I didn't do it correctly.
