### PR TITLE
Added symlink for MediaElch

### DIFF
--- a/Numix-Circle/48x48/apps/mediaelch.svg
+++ b/Numix-Circle/48x48/apps/mediaelch.svg
@@ -1,0 +1,1 @@
+MediaElch.svg


### PR DESCRIPTION
On Arch, with the latest version of MediaElch and using Hardcode-Fixer, the icon doesn't show up.
It needs to be named mediaelch instead of MediaElch, so I made a symlink to it.