### PR TITLE
Icon for Jasp Desktop

### DIFF
--- a/Numix-Circle/48x48/apps/jasp-desktop.svg
+++ b/Numix-Circle/48x48/apps/jasp-desktop.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <defs>
+  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+   <stop style="stop-color:#e4e4e4;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#eee;stop-opacity:1"/>
+  </linearGradient>
+ </defs>
+ <g>
+  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
+  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
+  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
+ </g>
+ <g>
+  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
+ </g>
+ <g>
+  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
+ </g>
+ <path d="m 32.5 12 a 1.5 1.5 0 0 0 -1.5 1.5 1.5 1.5 0 0 0 0.059 0.412 l -4.117 1.176 A 1.5 1.5 0 0 0 25.5 14 a 1.5 1.5 0 0 0 -1.5 1.5 1.5 1.5 0 0 0 1.289 1.482 L 23.301 30.894 19.705 28.977 19.969 26.998 A 1 1 0 0 0 20 27 a 1 1 0 0 0 1 -1 1 1 0 0 0 -1 -1 1 1 0 0 0 -1 1 1 1 0 0 0 0.033 0.248 l -2.064 0.512 A 1 1 0 0 0 16 26 a 1 1 0 0 0 -1 1 1 1 0 0 0 0.82 0.982 l -0.643 3.535 A 1 1 0 0 0 15 31.5 a 1 1 0 0 0 -1 1 1 1 0 0 0 1 1 1 1 0 0 0 0.881 -0.529 l 5.297 2.824 A 1.5 1.5 0 0 0 21 36.5 1.5 1.5 0 0 0 22.5 38 1.5 1.5 0 0 0 24 36.5 1.5 1.5 0 0 0 23.941 36.09 l 4.117 -1.176 A 1.5 1.5 0 0 0 29.5 36 1.5 1.5 0 0 0 31 34.5 1.5 1.5 0 0 0 29.713 33.02 L 32.29 14.982 A 1.5 1.5 0 0 0 32.5 15 1.5 1.5 0 0 0 34 13.5 1.5 1.5 0 0 0 32.5 12" style="fill:#000;opacity:1;fill-opacity:0.098;stroke:none"/>
+ <g transform="translate(-8.5,-762.00005)">
+  <path d="m 23.5 788 4.103 -1.017 -1.103 8.303" style="fill:#178dbd;opacity:1;fill-opacity:1;stroke:none"/>
+  <path d="m 22.5 793.5 1 -5.5 7.5 4 -1 5.5 z" style="fill:#1a9ace;opacity:1;fill-opacity:1;stroke:none"/>
+  <path d="m 33 776.5 7 -2 -3 21 -7 2 z" style="fill:#1ca8e1;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1.5" cy="774.5" cx="40" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="0.5" cy="774.5" cx="40" style="fill:#f9f9f9;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1.5" cy="776.5" cx="33" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="0.5" cy="776.5" cx="33" style="fill:#f9f9f9;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle cx="30" cy="797.5" r="1.5" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle cx="30" cy="797.5" r="0.5" style="fill:#f9f9f9;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1.5" cy="795.5" cx="37" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="0.5" cy="795.5" cx="37" style="fill:#f9f9f9;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1" cy="788" cx="23.5" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1" cy="793.5" cx="22.5" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+  <circle r="1" cy="787" cx="27.5" style="fill:#39b4e7;opacity:1;fill-opacity:1;stroke:none"/>
+ </g>
+</svg>

--- a/Numix-Circle/48x48/apps/jasp-desktop.svg
+++ b/Numix-Circle/48x48/apps/jasp-desktop.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
  <defs>
   <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-   <stop style="stop-color:#e4e4e4;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#eee;stop-opacity:1"/>
+   <stop style="stop-color:#b5d9f3;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#c6e2f6;stop-opacity:1"/>
   </linearGradient>
  </defs>
  <g>


### PR DESCRIPTION
statistical package
https://jasp-stats.org/

**Original icon:**
Icon0jasp-desktop
![jasp-desktop-ori](https://cloud.githubusercontent.com/assets/7050624/11321127/e08f55b0-90b2-11e5-930f-4a789fcf02ff.png)


**Pushed icon:**
![jasp-desktop](https://cloud.githubusercontent.com/assets/7050624/11321134/f1dfbddc-90b2-11e5-80b5-62650afc586d.png)



**Alt (subtle non-drop non-Numixy shadow below the circles):**
![jasp-desktop1](https://cloud.githubusercontent.com/assets/7050624/11321130/ed6feb8c-90b2-11e5-949e-1d1aaf3b56df.png)
![jasp-desktop1-2](https://cloud.githubusercontent.com/assets/7050624/11321131/ed76abac-90b2-11e5-9ef1-b672f39b8a35.png)
