### PR TITLE
Symlink for Butter

### DIFF
--- a/Numix-Circle/48x48/apps/butter.svg
+++ b/Numix-Circle/48x48/apps/butter.svg
@@ -1,0 +1,1 @@
+popcorntime.svg


### PR DESCRIPTION
Popcorn Time successor
http://butterproject.org/

Original icon:
![butter](https://cloud.githubusercontent.com/assets/7050624/11446223/2829beee-9534-11e5-9cfb-71d8809feefe.png)
