### PR TITLE
Tkpacman symlinks, yumex symlink enhancement

### DIFF
--- a/Numix-Circle/48x48/apps/tkpacman-icon.svg
+++ b/Numix-Circle/48x48/apps/tkpacman-icon.svg
@@ -1,0 +1,1 @@
+gdebi.svg

--- a/Numix-Circle/48x48/apps/tkpacman.svg
+++ b/Numix-Circle/48x48/apps/tkpacman.svg
@@ -1,0 +1,1 @@
+gdebi.svg

--- a/Numix-Circle/48x48/apps/yumex-dnf.svg
+++ b/Numix-Circle/48x48/apps/yumex-dnf.svg
@@ -1,1 +1,1 @@
-yumex.svg
+synaptic.svg

--- a/Numix-Circle/48x48/apps/yumex.svg
+++ b/Numix-Circle/48x48/apps/yumex.svg
@@ -1,1 +1,1 @@
-system-software-install.svg
+synaptic.svg


### PR DESCRIPTION
GUI for the pacman package manager
http://sourceforge.net/projects/tkpacman/

**Original icon:**
tkpacman.desktop
Icon=/usr/share/tkpacman/icons/tkpacman-icon.png
![tkpacman-icon](https://cloud.githubusercontent.com/assets/7050624/11453009/0201c960-95fb-11e5-8f96-caad0f489d22.png)

Furthermore I've edited tje yumex symlinks such that the yumex icon is more close to the original icon and looks distinct from the icon used by gnome-packagekit.