### PR TITLE
Added keepassx2 link.

### DIFF
--- a/Numix-Circle/48x48/apps/keepassx2.svg
+++ b/Numix-Circle/48x48/apps/keepassx2.svg
@@ -1,0 +1,1 @@
+keepassx.svg


### PR DESCRIPTION
KeePassX 2 is out and for Arch Linux the icon name is updated.