### PR TITLE
Add goa-account icons

### DIFF
--- a/Numix-Circle/48x48/apps/goa-account.svg
+++ b/Numix-Circle/48x48/apps/goa-account.svg
@@ -1,1 +1,0 @@
-goa-panel.svg


### PR DESCRIPTION
I created the live icon from the numix "live" icon and the background of the microsoft icon. It probably needs a shadow added. I created it using inkscape & `svgo --pretty --disable=collapseGroups,convertPathData live.svg`

Otherwise, I just set up the appropriate symlinks.