### PR TITLE
Distinct icon for Sky Chart

### DIFF
--- a/Numix-Circle/48x48/apps/skychart.svg
+++ b/Numix-Circle/48x48/apps/skychart.svg
@@ -1,26 +1,36 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
  <defs>
-  <linearGradient id="linearGradient4202" y1="47" x2="0" y2="1" gradientUnits="userSpaceOnUse">
+  <linearGradient id="linearGradient3764" x1="1" x2="47" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
    <stop style="stop-color:#415164;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#495a6f;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#485a70;stop-opacity:1"/>
   </linearGradient>
-  <linearGradient id="linearGradient4223" y1="21" x2="0" y2="4" gradientUnits="userSpaceOnUse">
-   <stop style="stop-color:#f4f4ec;stop-opacity:0.784"/>
-   <stop offset="0.123" style="stop-color:#f3f3ee;stop-opacity:0.242"/>
-   <stop offset="1" style="stop-color:#e6e6e6;stop-opacity:0.078"/>
-  </linearGradient>
-  <linearGradient id="linearGradient4212" gradientUnits="userSpaceOnUse" y1="47" x2="0" y2="1">
-   <stop style="stop-color:#3c3c3c;stop-opacity:1"/>
-   <stop offset="1" style="stop-color:#424242;stop-opacity:1"/>
-  </linearGradient>
-  <linearGradient id="linearGradient4269" gradientUnits="userSpaceOnUse" y1="13" x2="32" y2="6" x1="20">
-   <stop style="stop-color:#afafaf;stop-opacity:0.259"/>
+  <linearGradient id="linearGradient4245" y1="22" x2="0" y2="10" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66548709,1.2757569,-1.2515993,0.67833208,21.873437,-6.8605988)">
+   <stop style="stop-color:#c8c8c8;stop-opacity:0.259"/>
    <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:0"/>
   </linearGradient>
-  <linearGradient id="linearGradient4299" gradientUnits="userSpaceOnUse" y1="-8" x2="24" y2="-20" x1="4">
-   <stop style="stop-color:#c0c0c0;stop-opacity:0.702"/>
-   <stop offset="0.054" style="stop-color:#b4b4b4;stop-opacity:0.549"/>
-   <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:0.314"/>
+  <linearGradient id="linearGradient4215" y1="21" x2="0" y2="2" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66554528,1.2832529,-1.2517088,0.68231777,21.874299,-7.1373548)">
+   <stop style="stop-color:#d2d2d2;stop-opacity:0.706"/>
+   <stop offset="0.092" style="stop-color:#cecece;stop-opacity:0.565"/>
+   <stop offset="1" style="stop-color:#d7d7d7;stop-opacity:0.259"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4223" y1="21" x2="0" y2="4" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66548712,1.2814099,-1.2515994,0.68133784,21.873437,-7.0665988)">
+   <stop style="stop-color:#fdfdfb;stop-opacity:0.827"/>
+   <stop offset="0.254" style="stop-color:#fbfbf7;stop-opacity:0.275"/>
+   <stop offset="1" style="stop-color:#fafafa;stop-opacity:0.196"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4380" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66554528,1.2832529,-1.2517088,0.68231777,22.873861,-16.137414)" y1="21" x2="0" y2="2">
+   <stop style="stop-color:#000;stop-opacity:0.063"/>
+   <stop offset="0.092" style="stop-color:#000;stop-opacity:0.055"/>
+   <stop offset="1" style="stop-color:#000;stop-opacity:0.008"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4392" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66548712,1.2814099,-1.2515994,0.68133784,22.873394,-16.066826)" y1="21" x2="0" y2="4">
+   <stop style="stop-color:#000;stop-opacity:0.047"/>
+   <stop offset="0.254" style="stop-color:#000;stop-opacity:0.024"/>
+   <stop offset="1" style="stop-color:#000;stop-opacity:0.004"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4404" gradientUnits="userSpaceOnUse" gradientTransform="matrix(0.66548709,1.2757569,-1.2515993,0.67833208,22.873437,-15.860599)" y1="22" x2="0" y2="10">
+   <stop style="stop-color:#000;stop-opacity:0.047"/>
+   <stop offset="1" style="stop-color:#000;stop-opacity:0"/>
   </linearGradient>
  </defs>
  <g>
@@ -28,38 +38,36 @@
   <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
   <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
  </g>
- <g style="clip-path:none;fill:#4c7ebd;fill-opacity:1">
-  <path d="m 24,1 c 12.703,0 23,10.297 23,23 0,6.3515 -2.57425,12.1015 -6.736375,16.263625 l -32.52725,0 C 3.57425,36.1015 1,30.3515 1,24 1,11.297 11.297,1 24,1 Z" style="fill:url(#linearGradient4202)"/>
-  <path d="m 21 36 c -2.486 0.15 -4.717 1.412 -7.379 1.01 c -1.477 -0.225 -5.271 0.286 -7.701 1.203 c 4.211 5.351 10.742 8.791 18.08 8.791 c 8.04 0 15.11 -4.127 19.223 -10.375 c -2.106 -0.767 -5.285 -0.654 -6.9 -0.418 c -3.491 0.511 -8.383 3.595 -10.27 1.885 c -1.367 -1.239 -3.134 -2.207 -5.05 -2.092 z" style="fill:url(#linearGradient4212)"/>
+ <g>
+  <path d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z" style="fill:url(#linearGradient3764);fill-opacity:1"/>
  </g>
- <circle cx="29.5" cy="11.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
- <circle cx="35.5" cy="9.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <g transform="translate(1.5727658e-4,0)">
+  <path d="m 45.5 27.515 c 0 0 -29.611 7.866 -32.27 2.763 c -2.662 -5.103 17.773 -27.28 17.773 -27.28" style="fill:url(#linearGradient4404);fill-opacity:1"/>
+  <path d="m 19.565 30.11 c -2.78 1.515 -5.672 1.446 -6.338 0.163 -0.829 -1.598 0.896 -3.78 3.676 -5.296 c 2.78 -1.515 19.679 -8.493 20.11 -7.668 0.428 0.825 -14.664 11.286 -17.445 12.801" style="fill:url(#linearGradient4380);fill-opacity:1"/>
+  <path d="m 19.232 29.473 c -2.049 1.115 -4.915 1.665 -5.504 0.531 -0.61 -1.175 1.459 -3.26 3.508 -4.375 2.049 -1.115 15.782 -6.708 16.02 -6.254 0.236 0.454 -11.972 8.983 -14.02 10.1 z" style="fill:url(#linearGradient4392);fill-opacity:1"/>
+ </g>
  <g>
   <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
  </g>
- <g transform="matrix(1.1174404,0.2219077,-0.36831098,1.0876466,4.7204107,-9.0583435)" style="clip-path:none">
-  <g transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,14.454058,-13.895184)">
-   <g>
-    <path transform="matrix(0.47194859,-0.71388996,0.80994197,0.40838014,4.7137578,27.115043)" d="m 25.408 1.047 c -4.645 5.58 -9.373 12.01 -8.238 13.994 c 1.967 3.438 22.642 -3.167 25.711 -4.168 c -3.904 -5.604 -10.235 -9.389 -17.473 -9.826 z" style="fill:url(#linearGradient4269);fill-opacity:1"/>
-    <path transform="matrix(0.47194859,-0.71388996,0.80994197,0.40838014,4.7137578,27.115043)" d="m 35.22 3.924 c -3.968 1.482 -13.07 5.744 -14.906 6.816 c -2.333 1.36 -3.802 3.148 -3.143 4.301 c 0.53 0.926 2.928 0.764 5.262 -0.596 c 1.927 -1.123 10.828 -7.448 13.715 -9.975 c -0.304 -0.19 -0.614 -0.371 -0.928 -0.547 z" style="fill:url(#linearGradient4299);fill-opacity:1"/>
-    <path d="m 26.5 17 c 0 1.637 -0.615 3.6 -1.5 3.6 -0.917 0 -1.5 -1.963 -1.5 -3.6 0 -1.637 1.146 -12 1.5 -12 0.354 0 1.5 10.363 1.5 12 z" style="fill:url(#linearGradient4223);fill-opacity:1"/>
-   </g>
-  </g>
+ <g transform="translate(0,-9.9999998)">
+  <path d="m 44.5 36.515 c 0 0 -29.611 7.866 -32.27 2.763 c -2.662 -5.103 17.773 -26.28 17.773 -26.28" style="fill:url(#linearGradient4245);fill-opacity:1"/>
+  <path d="m 18.565 39.11 c -2.78 1.515 -5.672 1.446 -6.338 0.163 -0.829 -1.598 0.896 -3.78 3.676 -5.296 2.78 -1.515 19.679 -8.493 20.11 -7.668 0.428 0.825 -14.664 11.286 -17.445 12.801 z" style="fill:url(#linearGradient4215);fill-opacity:1"/>
+  <path d="m 18.232 38.474 c -2.049 1.115 -4.915 1.665 -5.504 0.531 -0.61 -1.175 1.459 -3.26 3.508 -4.375 2.049 -1.115 15.782 -6.708 16.02 -6.254 0.236 0.454 -11.972 8.983 -14.02 10.1 z" style="fill:url(#linearGradient4223);fill-opacity:1"/>
  </g>
+ <circle cx="29.5" cy="11.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="35.5" cy="9.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
  <circle cx="14.5" cy="16.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.758"/>
- <circle cx="20.5" cy="21.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="22.5" cy="18.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
  <circle cx="38.5" cy="20.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
  <circle cx="27.5" cy="29.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
- <circle cx="12.5" cy="24.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
- <circle cx="19.5" cy="7.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="11.5" cy="23.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="21.5" cy="9.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="9.5" cy="15.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
- <circle cx="31.5" cy="19.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="37.5" cy="14.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
  <circle cx="36.5" cy="29.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
- <circle cx="18.5" cy="30.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="26.5" cy="34.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="6.5" cy="28.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="7.5" cy="20.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
- <circle cx="25.5" cy="22.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="42.5" cy="22.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="11.5" cy="10.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
  <circle cx="15.5" cy="10.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
@@ -70,8 +78,18 @@
  <circle cx="25.5" cy="6.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
  <circle cx="22.5" cy="3.5" r="0.5" style="fill:#ece1d0;fill-opacity:0.757;stroke:none"/>
  <circle cx="40.5" cy="16.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
- <circle cx="25.5" cy="17.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="25.5" cy="15.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
  <circle cx="40.5" cy="28.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
  <circle cx="5.5" cy="24.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757;stroke:none"/>
- <circle r="0.5" cy="30.5" cx="12.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle r="0.5" cy="30.5" cx="9.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <path d="m 23.5 4 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 z m -7 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 z m 10 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 z m -4 3 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 14 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -24 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 4 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 14 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -23 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 14 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 17 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -28 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 16 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -11 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 26 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -18 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -15 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 9 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 22 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 4 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -31 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -6 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 27 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -26 3 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 34 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -13 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 9 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -27 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 12 4 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 5 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -16 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 6 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 21 0 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -5 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -10 2 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m -7 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5 m 12 1 c -0.276 0 -0.5 0.224 -0.5 0.5 0 0.276 0.224 0.5 0.5 0.5 0.276 0 0.5 -0.224 0.5 -0.5 0 -0.276 -0.224 -0.5 -0.5 -0.5" style="fill:#000;opacity:0.1;fill-opacity:1;stroke:none"/>
+ <circle cx="21.5" cy="34.5" r="0.5" style="fill:#b0c2ca;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="32.5" cy="37.5" r="0.5" style="fill:#c8cbb8;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="10.5" cy="35.5" r="0.5" style="fill:#c8cbb8;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="27.5" cy="41.5" r="0.5" style="fill:#b0c2ca;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="20.5" cy="14.5" r="0.5" style="fill:#c8ccb9;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="15.5" cy="40.5" r="0.5" style="fill:#b0c2ca;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="16.5" cy="35.5" r="0.5" style="fill:#c8cbb8;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="22.5" cy="39.5" r="0.5" style="fill:#c8cbb8;opacity:1;fill-opacity:1;stroke:none"/>
+ <circle cx="37.5" cy="35.5" r="0.5" style="fill:#b0c2ca;opacity:1;fill-opacity:1;stroke:none"/>
 </svg>

--- a/Numix-Circle/48x48/apps/skychart.svg
+++ b/Numix-Circle/48x48/apps/skychart.svg
@@ -1,1 +1,77 @@
-stellarium.svg
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+ <defs>
+  <linearGradient id="linearGradient4202" y1="47" x2="0" y2="1" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#415164;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#495a6f;stop-opacity:1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4223" y1="21" x2="0" y2="4" gradientUnits="userSpaceOnUse">
+   <stop style="stop-color:#f4f4ec;stop-opacity:0.784"/>
+   <stop offset="0.123" style="stop-color:#f3f3ee;stop-opacity:0.242"/>
+   <stop offset="1" style="stop-color:#e6e6e6;stop-opacity:0.078"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4212" gradientUnits="userSpaceOnUse" y1="47" x2="0" y2="1">
+   <stop style="stop-color:#3c3c3c;stop-opacity:1"/>
+   <stop offset="1" style="stop-color:#424242;stop-opacity:1"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4269" gradientUnits="userSpaceOnUse" y1="13" x2="32" y2="6" x1="20">
+   <stop style="stop-color:#afafaf;stop-opacity:0.259"/>
+   <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:0"/>
+  </linearGradient>
+  <linearGradient id="linearGradient4299" gradientUnits="userSpaceOnUse" y1="-8" x2="24" y2="-20" x1="4">
+   <stop style="stop-color:#c0c0c0;stop-opacity:0.702"/>
+   <stop offset="0.054" style="stop-color:#b4b4b4;stop-opacity:0.549"/>
+   <stop offset="1" style="stop-color:#b4b4b4;stop-opacity:0.314"/>
+  </linearGradient>
+ </defs>
+ <g>
+  <path d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z" style="opacity:0.05"/>
+  <path d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z" style="opacity:0.1"/>
+  <path d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z" style="opacity:0.2"/>
+ </g>
+ <g style="clip-path:none;fill:#4c7ebd;fill-opacity:1">
+  <path d="m 24,1 c 12.703,0 23,10.297 23,23 0,6.3515 -2.57425,12.1015 -6.736375,16.263625 l -32.52725,0 C 3.57425,36.1015 1,30.3515 1,24 1,11.297 11.297,1 24,1 Z" style="fill:url(#linearGradient4202)"/>
+  <path d="m 21 36 c -2.486 0.15 -4.717 1.412 -7.379 1.01 c -1.477 -0.225 -5.271 0.286 -7.701 1.203 c 4.211 5.351 10.742 8.791 18.08 8.791 c 8.04 0 15.11 -4.127 19.223 -10.375 c -2.106 -0.767 -5.285 -0.654 -6.9 -0.418 c -3.491 0.511 -8.383 3.595 -10.27 1.885 c -1.367 -1.239 -3.134 -2.207 -5.05 -2.092 z" style="fill:url(#linearGradient4212)"/>
+ </g>
+ <circle cx="29.5" cy="11.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="35.5" cy="9.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <g>
+  <path d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z" style="opacity:0.1"/>
+ </g>
+ <g transform="matrix(1.1174404,0.2219077,-0.36831098,1.0876466,4.7204107,-9.0583435)" style="clip-path:none">
+  <g transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,14.454058,-13.895184)">
+   <g>
+    <path transform="matrix(0.47194859,-0.71388996,0.80994197,0.40838014,4.7137578,27.115043)" d="m 25.408 1.047 c -4.645 5.58 -9.373 12.01 -8.238 13.994 c 1.967 3.438 22.642 -3.167 25.711 -4.168 c -3.904 -5.604 -10.235 -9.389 -17.473 -9.826 z" style="fill:url(#linearGradient4269);fill-opacity:1"/>
+    <path transform="matrix(0.47194859,-0.71388996,0.80994197,0.40838014,4.7137578,27.115043)" d="m 35.22 3.924 c -3.968 1.482 -13.07 5.744 -14.906 6.816 c -2.333 1.36 -3.802 3.148 -3.143 4.301 c 0.53 0.926 2.928 0.764 5.262 -0.596 c 1.927 -1.123 10.828 -7.448 13.715 -9.975 c -0.304 -0.19 -0.614 -0.371 -0.928 -0.547 z" style="fill:url(#linearGradient4299);fill-opacity:1"/>
+    <path d="m 26.5 17 c 0 1.637 -0.615 3.6 -1.5 3.6 -0.917 0 -1.5 -1.963 -1.5 -3.6 0 -1.637 1.146 -12 1.5 -12 0.354 0 1.5 10.363 1.5 12 z" style="fill:url(#linearGradient4223);fill-opacity:1"/>
+   </g>
+  </g>
+ </g>
+ <circle cx="14.5" cy="16.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.758"/>
+ <circle cx="20.5" cy="21.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="38.5" cy="20.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="27.5" cy="29.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="12.5" cy="24.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="19.5" cy="7.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="9.5" cy="15.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="31.5" cy="19.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="37.5" cy="14.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="36.5" cy="29.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="18.5" cy="30.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="6.5" cy="28.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="7.5" cy="20.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="25.5" cy="22.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="42.5" cy="22.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="11.5" cy="10.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="15.5" cy="10.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+ <circle cx="15.5" cy="5.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="6.5" cy="13.5" r="0.5" style="fill:#ece1d0;fill-opacity:0.757"/>
+ <circle cx="32.5" cy="25.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757"/>
+ <circle cx="16.5" cy="20.5" r="0.5" style="fill:#ece1d0;fill-opacity:0.758"/>
+ <circle cx="25.5" cy="6.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="22.5" cy="3.5" r="0.5" style="fill:#ece1d0;fill-opacity:0.757;stroke:none"/>
+ <circle cx="40.5" cy="16.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="25.5" cy="17.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="40.5" cy="28.5" r="0.5" style="fill:#d3e5e9;fill-opacity:0.757;stroke:none"/>
+ <circle cx="5.5" cy="24.5" r="0.5" style="fill:#f1f0d1;fill-opacity:0.757;stroke:none"/>
+ <circle r="0.5" cy="30.5" cx="12.5" style="fill:#d3e5e9;fill-opacity:0.758"/>
+</svg>


### PR DESCRIPTION
I've had this resting on my disk for a while:
Diverging from the guidelines but recognisable and small sizes and true to the original icon:
![skychart](https://cloud.githubusercontent.com/assets/7050624/12888072/917ea21a-ce78-11e5-8bc6-ac0656e871ba.png)

Alt with shadows:
![skychart-shadow](https://cloud.githubusercontent.com/assets/7050624/12898346/7f6e2332-ceac-11e5-81fc-08cebf9539fb.png)


Maybe a bigger meteor?
