### PR TITLE
Icon for RuneScape

### DIFF
--- a/Numix-Circle/48x48/apps/runescape.svg
+++ b/Numix-Circle/48x48/apps/runescape.svg
@@ -12,7 +12,10 @@
    id="svg2"
    version="1.1"
    inkscape:version="0.91 r13725"
-   sodipodi:docname="runescape.svg">
+   sodipodi:docname="runescape.svg"
+   inkscape:export-filename="/home/misterio7/Pictures/Numix/rsu.png"
+   inkscape:export-xdpi="490.21277"
+   inkscape:export-ydpi="490.21277">
   <metadata
      id="metadata64">
     <rdf:RDF>
@@ -21,7 +24,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -37,10 +40,10 @@
      inkscape:window-width="1600"
      inkscape:window-height="844"
      id="namedview62"
-     showgrid="false"
-     inkscape:zoom="32.000001"
-     inkscape:cx="25.375878"
-     inkscape:cy="24.391797"
+     showgrid="true"
+     inkscape:zoom="11.313709"
+     inkscape:cx="-5.6349322"
+     inkscape:cy="24.193991"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -60,7 +63,7 @@
          offset="0"
          id="stop4302" />
       <stop
-         style="stop-color:#163c4e;stop-opacity:1"
+         style="stop-color:#11222f;stop-opacity:1"
          offset="1"
          id="stop4304" />
     </linearGradient>
@@ -142,10 +145,10 @@
        inkscape:collect="always"
        xlink:href="#linearGradient4300"
        id="linearGradient4306"
-       x1="35.75"
-       y1="47"
-       x2="-54.662952"
-       y2="-90.658638"
+       x1="1.0068517"
+       y1="46.996094"
+       x2="1.0068517"
+       y2="1.0260559"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <g

--- a/Numix-Circle/48x48/apps/runescape.svg
+++ b/Numix-Circle/48x48/apps/runescape.svg
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="runescape.svg">
+  <metadata
+     id="metadata64">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="844"
+     id="namedview62"
+     showgrid="false"
+     inkscape:zoom="32.000001"
+     inkscape:cx="25.375878"
+     inkscape:cy="24.391797"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2"
+     showguides="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4224" />
+  </sodipodi:namedview>
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4300">
+      <stop
+         style="stop-color:#0c1821;stop-opacity:1"
+         offset="0"
+         id="stop4302" />
+      <stop
+         style="stop-color:#163c4e;stop-opacity:1"
+         offset="1"
+         id="stop4304" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4282">
+      <stop
+         style="stop-color:#eeeeee;stop-opacity:1;"
+         offset="0"
+         id="stop4284" />
+      <stop
+         style="stop-color:#eeeeee;stop-opacity:0"
+         offset="1"
+         id="stop4286" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3845"
+       y1="47"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         style="stop-color:#4678b0;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#5082ba;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-379022256">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-384196710">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+    <linearGradient
+       id="linear0"
+       gradientUnits="userSpaceOnUse"
+       x1="3.669"
+       x2="10.442"
+       gradientTransform="matrix(3.543307,0,0,3.543307,-1,0)">
+      <stop
+         style="stop-color:#e2f4fb;stop-opacity:1"
+         id="stop22" />
+      <stop
+         offset="1"
+         style="stop-color:#f9f9f9;stop-opacity:1"
+         id="stop24" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4282"
+       id="linearGradient4288"
+       x1="26"
+       y1="24"
+       x2="-23.564133"
+       y2="42.035995"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1536963,0,0,1.1536963,-4.7240259,-0.39765935)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4300"
+       id="linearGradient4306"
+       x1="35.75"
+       y1="47"
+       x2="-54.662952"
+       y2="-90.658638"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <g
+     id="g26">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path28" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path30" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path32" />
+  </g>
+  <g
+     id="g34"
+     style="fill-opacity:1;fill:url(#linearGradient4306)">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:url(#linearGradient4306);fill-opacity:1.0"
+       id="path36" />
+  </g>
+  <g
+     id="g38">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path40" />
+  </g>
+  <path
+     sodipodi:nodetypes="ccccccccccccccccccccccc"
+     inkscape:connector-curvature="0"
+     id="path4163"
+     d="m 25.141206,11.210834 c -1.409145,-2.8182908 3.346721,-2.8182908 1.937574,0 l 0,5.98887 4.221933,0 1.056859,1.056859 -1.056859,1.056858 -1.056859,-0.880715 c 0,0 -1.932071,-0.52843 -1.931868,0.3538 l -2.03e-4,15.249386 0.704573,2.113719 -2.900169,4.755866 -3.088699,-4.755866 0.880716,-2.113719 0,-6.56859 -1.233003,-1.233003 1.233003,-1.409145 0,-6.040163 c 0,-0.880715 -1.937576,-0.352285 -1.937576,-0.352285 l -1.056859,0.880715 -1.056859,-1.056858 1.056859,-1.056859 4.227437,0 z"
+     style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+  <path
+     style="opacity:1;fill:url(#linearGradient4288);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 23.141206,9.2108336 c -1.409145,-2.8182904 3.346721,-2.8182904 1.937574,0 l 0,5.9888704 4.221933,0 1.056859,1.056859 -1.056859,1.056858 -1.056859,-0.880715 c 0,0 -1.932071,-0.52843 -1.931868,0.3538 l -2.03e-4,15.249386 0.704573,2.113719 -2.900169,4.755866 -3.088699,-4.755866 0.880716,-2.113719 0,-6.56859 -1.233003,-1.233003 1.233003,-1.409145 0,-6.040163 c 0,-0.880715 -1.937576,-0.352285 -1.937576,-0.352285 l -1.056859,0.880715 -1.056859,-1.056858 1.056859,-1.056859 4.227437,0 z"
+     id="path4226"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="ccccccccccccccccccccccc" />
+</svg>

--- a/Numix-Circle/48x48/apps/runescape.svg
+++ b/Numix-Circle/48x48/apps/runescape.svg
@@ -13,7 +13,7 @@
    version="1.1"
    inkscape:version="0.91 r13725"
    sodipodi:docname="runescape.svg"
-   inkscape:export-filename="/home/misterio7/Pictures/Numix/rsu.png"
+   inkscape:export-filename="/home/misterio7/Pictures/Numix/runescape.svg"
    inkscape:export-xdpi="490.21277"
    inkscape:export-ydpi="490.21277">
   <metadata
@@ -24,7 +24,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -41,9 +41,9 @@
      inkscape:window-height="844"
      id="namedview62"
      showgrid="true"
-     inkscape:zoom="11.313709"
-     inkscape:cx="-5.6349322"
-     inkscape:cy="24.193991"
+     inkscape:zoom="8"
+     inkscape:cx="-17.173596"
+     inkscape:cy="8.0118498"
      inkscape:window-x="0"
      inkscape:window-y="27"
      inkscape:window-maximized="1"
@@ -59,25 +59,13 @@
        inkscape:collect="always"
        id="linearGradient4300">
       <stop
-         style="stop-color:#0c1821;stop-opacity:1"
+         style="stop-color:#11222f;stop-opacity:1"
          offset="0"
          id="stop4302" />
       <stop
-         style="stop-color:#11222f;stop-opacity:1"
+         style="stop-color:#162d3e;stop-opacity:1"
          offset="1"
          id="stop4304" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient4282">
-      <stop
-         style="stop-color:#eeeeee;stop-opacity:1;"
-         offset="0"
-         id="stop4284" />
-      <stop
-         style="stop-color:#eeeeee;stop-opacity:0"
-         offset="1"
-         id="stop4286" />
     </linearGradient>
     <linearGradient
        id="linearGradient3845"
@@ -133,16 +121,6 @@
     </linearGradient>
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4282"
-       id="linearGradient4288"
-       x1="26"
-       y1="24"
-       x2="-23.564133"
-       y2="42.035995"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.1536963,0,0,1.1536963,-4.7240259,-0.39765935)" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4300"
        id="linearGradient4306"
        x1="1.0068517"
@@ -184,12 +162,12 @@
   <path
      sodipodi:nodetypes="ccccccccccccccccccccccc"
      inkscape:connector-curvature="0"
-     id="path4163"
-     d="m 25.141206,11.210834 c -1.409145,-2.8182908 3.346721,-2.8182908 1.937574,0 l 0,5.98887 4.221933,0 1.056859,1.056859 -1.056859,1.056858 -1.056859,-0.880715 c 0,0 -1.932071,-0.52843 -1.931868,0.3538 l -2.03e-4,15.249386 0.704573,2.113719 -2.900169,4.755866 -3.088699,-4.755866 0.880716,-2.113719 0,-6.56859 -1.233003,-1.233003 1.233003,-1.409145 0,-6.040163 c 0,-0.880715 -1.937576,-0.352285 -1.937576,-0.352285 l -1.056859,0.880715 -1.056859,-1.056858 1.056859,-1.056859 4.227437,0 z"
-     style="opacity:0.1;fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+     id="path4159"
+     d="m 24,11 c -1.454158,-2.6580657 3.454163,-2.6580657 2,0 l 0,5.6 4.4,0 1.1,1 -1.1,1.1 -1.1,-0.9 c 0,0 -2.300213,-0.432075 -2.3,0.4 l 0,14.3 1.000377,2 L 25,39 22.000377,34.5 23,32.5 23,26.5 21.9,25 23,23.5 23,18.2 c 0,-0.830645 -2.3,-0.4 -2.3,-0.4 l -1.1,0.9 -1.1,-1.1 1.1,-1 4.4,0 z"
+     style="opacity:0.1;fill:#000000;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
   <path
-     style="opacity:1;fill:url(#linearGradient4288);fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 23.141206,9.2108336 c -1.409145,-2.8182904 3.346721,-2.8182904 1.937574,0 l 0,5.9888704 4.221933,0 1.056859,1.056859 -1.056859,1.056858 -1.056859,-0.880715 c 0,0 -1.932071,-0.52843 -1.931868,0.3538 l -2.03e-4,15.249386 0.704573,2.113719 -2.900169,4.755866 -3.088699,-4.755866 0.880716,-2.113719 0,-6.56859 -1.233003,-1.233003 1.233003,-1.409145 0,-6.040163 c 0,-0.880715 -1.937576,-0.352285 -1.937576,-0.352285 l -1.056859,0.880715 -1.056859,-1.056858 1.056859,-1.056859 4.227437,0 z"
+     style="opacity:1;fill:#dfdfdf;fill-opacity:0.94117647;fill-rule:evenodd;stroke:none;stroke-width:0.24778955px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 23,10 c -1.454158,-2.6580657 3.454163,-2.6580657 2,0 l 0,5.6 4.4,0 1.1,1 -1.1,1.1 -1.1,-0.9 c 0,0 -2.300213,-0.432075 -2.3,0.4 l 0,14.3 1.000377,2 L 24,38 21.000377,33.5 22,31.5 22,25.5 20.9,24 22,22.5 22,17.2 c 0,-0.830645 -2.3,-0.4 -2.3,-0.4 l -1.1,0.9 -1.1,-1.1 1.1,-1 4.4,0 z"
      id="path4226"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="ccccccccccccccccccccccc" />


### PR DESCRIPTION
Fixes #2855

Runescape Linux/Unix Client repo: https://github.com/HikariKnight/rsu-client/

Original:
![Original](https://cloud.githubusercontent.com/assets/5727578/13125452/beef07f4-d5ac-11e5-87f1-5ea21bc531ae.png)

Pushed:
![runescape](https://cloud.githubusercontent.com/assets/5727578/13165401/6c942824-d6a4-11e5-9a0c-687154ce2d10.png)

The icon line in the original .desktop is hardcoded: `Icon=/opt/runescape/share/img/runescape.png`