### PR TITLE
Icon for LTSpice

### DIFF
--- a/Numix-Circle/48x48/apps/ltspice.svg
+++ b/Numix-Circle/48x48/apps/ltspice.svg
@@ -41,8 +41,8 @@
      id="namedview65"
      showgrid="false"
      inkscape:zoom="11.313709"
-     inkscape:cx="15.501814"
-     inkscape:cy="30.530397"
+     inkscape:cx="17.007853"
+     inkscape:cy="31.818551"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -57,11 +57,11 @@
     <linearGradient
        id="linearGradient3788">
       <stop
-         style="stop-color:#dbd5d1;stop-opacity:1;"
+         style="stop-color:#dfcdcd;stop-opacity:1;"
          offset="0"
          id="stop3790" />
       <stop
-         style="stop-color:#e3dddd;stop-opacity:1;"
+         style="stop-color:#e6dada;stop-opacity:1;"
          offset="1"
          id="stop3792" />
     </linearGradient>

--- a/Numix-Circle/48x48/apps/ltspice.svg
+++ b/Numix-Circle/48x48/apps/ltspice.svg
@@ -5,6 +5,7 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
@@ -39,15 +40,31 @@
      inkscape:window-height="1056"
      id="namedview65"
      showgrid="false"
-     inkscape:zoom="27.812867"
-     inkscape:cx="23.739134"
-     inkscape:cy="28.253079"
+     inkscape:zoom="11.313709"
+     inkscape:cx="15.501814"
+     inkscape:cy="30.530397"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2" />
+     inkscape:current-layer="svg2"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3012" />
+  </sodipodi:namedview>
   <defs
      id="defs4">
+    <linearGradient
+       id="linearGradient3788">
+      <stop
+         style="stop-color:#dbd5d1;stop-opacity:1;"
+         offset="0"
+         id="stop3790" />
+      <stop
+         style="stop-color:#e3dddd;stop-opacity:1;"
+         offset="1"
+         id="stop3792" />
+    </linearGradient>
     <linearGradient
        id="linearGradient3764"
        x1="1"
@@ -86,6 +103,15 @@
            id="path19" />
       </g>
     </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3788"
+       id="linearGradient3804"
+       x1="22.781593"
+       y1="38.592419"
+       x2="22.781593"
+       y2="4.2010102"
+       gradientUnits="userSpaceOnUse" />
   </defs>
   <g
      id="g21">
@@ -104,10 +130,10 @@
   </g>
   <g
      id="g29"
-     style="fill:#e6e6e6">
+     style="fill:url(#linearGradient3804);stroke:none;fill-opacity:1.0">
     <path
        d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
-       style="fill:#e6e6e6;fill-opacity:1"
+       style="fill:url(#linearGradient3804);fill-opacity:1.0;stroke:none"
        id="path31" />
   </g>
   <g
@@ -119,8 +145,8 @@
   </g>
   <g
      id="g3094-7"
-     transform="matrix(0.16248822,0,0,0.16248822,-24.967857,9.839555)"
-     style="opacity:0.10000000000000001;fill:#000000;stroke:none">
+     transform="matrix(0.12513094,0,0,0.12513094,-13.645149,12.752687)"
+     style="opacity:0.1;fill:#000000;stroke:none">
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
@@ -135,20 +161,20 @@
        style="fill:#000000;fill-opacity:1;stroke:none" />
   </g>
   <g
-     style="fill:#aa0000;stroke:none"
+     style="fill:#c32828;stroke:none;fill-opacity:1"
      id="g3094"
-     transform="matrix(0.16248822,0,0,0.16248822,-25.968078,8.839417)">
+     transform="matrix(0.12513094,0,0,0.12513094,-14.415412,11.982488)">
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path3074"
        d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
-       style="fill:#aa0000;fill-opacity:1;stroke:none" />
+       style="fill:#c32828;fill-opacity:1;stroke:none" />
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path3074-7"
        d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.10169 C 355.22612,56.008196 388.35146,133.64656 321.55931,144.1017 z"
-       style="fill:#aa0000;fill-opacity:1;stroke:none" />
+       style="fill:#c32828;fill-opacity:1;stroke:none" />
   </g>
 </svg>

--- a/Numix-Circle/48x48/apps/ltspice.svg
+++ b/Numix-Circle/48x48/apps/ltspice.svg
@@ -41,12 +41,12 @@
      id="namedview65"
      showgrid="false"
      inkscape:zoom="11.313709"
-     inkscape:cx="17.007853"
-     inkscape:cy="31.818551"
+     inkscape:cx="27.844352"
+     inkscape:cy="20.144493"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="svg2"
+     inkscape:current-layer="g29"
      inkscape:snap-global="false">
     <inkscape:grid
        type="xygrid"
@@ -54,6 +54,17 @@
   </sodipodi:namedview>
   <defs
      id="defs4">
+    <linearGradient
+       id="linearGradient3779">
+      <stop
+         id="stop3781"
+         offset="0"
+         style="stop-color:#dfcdcd;stop-opacity:1" />
+      <stop
+         id="stop3783"
+         offset="1"
+         style="stop-color:#e7d9d9;stop-opacity:1" />
+    </linearGradient>
     <linearGradient
        id="linearGradient3788">
       <stop
@@ -66,44 +77,6 @@
          id="stop3792" />
     </linearGradient>
     <linearGradient
-       id="linearGradient3764"
-       x1="1"
-       x2="47"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
-      <stop
-         style="stop-color:#d3d3d3;stop-opacity:1"
-         id="stop7" />
-      <stop
-         offset="1"
-         style="stop-color:#ddd;stop-opacity:1"
-         id="stop9" />
-    </linearGradient>
-    <clipPath
-       id="clipPath-028714355">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g12">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           style="fill:#1890d0"
-           id="path14" />
-      </g>
-    </clipPath>
-    <clipPath
-       id="clipPath-036441573">
-      <g
-         transform="translate(0,-1004.3622)"
-         id="g17">
-        <path
-           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
-           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
-           style="fill:#1890d0"
-           id="path19" />
-      </g>
-    </clipPath>
-    <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3788"
        id="linearGradient3804"
@@ -112,6 +85,15 @@
        x2="22.781593"
        y2="4.2010102"
        gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3779"
+       id="linearGradient3009"
+       gradientUnits="userSpaceOnUse"
+       x1="1.0003443"
+       y1="46.996197"
+       x2="1.0003443"
+       y2="0.99788517" />
   </defs>
   <g
      id="g21">
@@ -133,7 +115,7 @@
      style="fill:url(#linearGradient3804);stroke:none;fill-opacity:1.0">
     <path
        d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
-       style="fill:url(#linearGradient3804);fill-opacity:1.0;stroke:none"
+       style="fill:url(#linearGradient3009);fill-opacity:1.0;stroke:none"
        id="path31" />
   </g>
   <g
@@ -144,26 +126,26 @@
        id="path63" />
   </g>
   <g
-     id="g3094-7"
-     transform="matrix(0.12513094,0,0,0.12513094,-13.645149,12.752687)"
-     style="opacity:0.1;fill:#000000;stroke:none">
+     transform="matrix(0.1198665,0,0,0.1194704,-11.721812,13.784112)"
+     id="g3791"
+     style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none">
     <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       id="path3074-4"
+       style="fill:#000000;fill-opacity:1;stroke:none"
        d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
-       style="fill:#000000;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ccccc"
+       id="path3793"
        inkscape:connector-curvature="0"
-       id="path3074-7-0"
-       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.10169 C 355.22612,56.008196 388.35146,133.64656 321.55931,144.1017 z"
-       style="fill:#000000;fill-opacity:1;stroke:none" />
+       sodipodi:nodetypes="ccccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none"
+       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 z"
+       id="path3795"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
   </g>
   <g
-     style="fill:#c32828;stroke:none;fill-opacity:1"
+     style="fill:#c32828;fill-opacity:1;stroke:none"
      id="g3094"
-     transform="matrix(0.12513094,0,0,0.12513094,-14.415412,11.982488)">
+     transform="matrix(0.1198665,0,0,0.1194704,-12.721812,12.784112)">
     <path
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
@@ -174,7 +156,7 @@
        sodipodi:nodetypes="ccccc"
        inkscape:connector-curvature="0"
        id="path3074-7"
-       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.10169 C 355.22612,56.008196 388.35146,133.64656 321.55931,144.1017 z"
+       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 z"
        style="fill:#c32828;fill-opacity:1;stroke:none" />
   </g>
 </svg>

--- a/Numix-Circle/48x48/apps/ltspice.svg
+++ b/Numix-Circle/48x48/apps/ltspice.svg
@@ -1,0 +1,154 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.48.4 r9939"
+   width="100%"
+   height="100%"
+   sodipodi:docname="ltspice.svg">
+  <metadata
+     id="metadata67">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1855"
+     inkscape:window-height="1056"
+     id="namedview65"
+     showgrid="false"
+     inkscape:zoom="27.812867"
+     inkscape:cx="23.739134"
+     inkscape:cy="28.253079"
+     inkscape:window-x="65"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg2" />
+  <defs
+     id="defs4">
+    <linearGradient
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#d3d3d3;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#ddd;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
+    <clipPath
+       id="clipPath-028714355">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g12">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path14" />
+      </g>
+    </clipPath>
+    <clipPath
+       id="clipPath-036441573">
+      <g
+         transform="translate(0,-1004.3622)"
+         id="g17">
+        <path
+           d="m -24 13 c 0 1.105 -0.672 2 -1.5 2 -0.828 0 -1.5 -0.895 -1.5 -2 0 -1.105 0.672 -2 1.5 -2 0.828 0 1.5 0.895 1.5 2 z"
+           transform="matrix(15.333333,0,0,11.5,414.99999,878.8622)"
+           style="fill:#1890d0"
+           id="path19" />
+      </g>
+    </clipPath>
+  </defs>
+  <g
+     id="g21">
+    <path
+       d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
+       style="opacity:0.05"
+       id="path23" />
+    <path
+       d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
+       style="opacity:0.1"
+       id="path25" />
+    <path
+       d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
+       style="opacity:0.2"
+       id="path27" />
+  </g>
+  <g
+     id="g29"
+     style="fill:#e6e6e6">
+    <path
+       d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
+       style="fill:#e6e6e6;fill-opacity:1"
+       id="path31" />
+  </g>
+  <g
+     id="g61">
+    <path
+       d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
+       style="opacity:0.1"
+       id="path63" />
+  </g>
+  <g
+     id="g3094-7"
+     transform="matrix(0.16248822,0,0,0.16248822,-24.967857,9.839555)"
+     style="opacity:0.10000000000000001;fill:#000000;stroke:none">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3074-4"
+       d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
+       style="fill:#000000;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3074-7-0"
+       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.10169 C 355.22612,56.008196 388.35146,133.64656 321.55931,144.1017 z"
+       style="fill:#000000;fill-opacity:1;stroke:none" />
+  </g>
+  <g
+     style="fill:#aa0000;stroke:none"
+     id="g3094"
+     transform="matrix(0.16248822,0,0,0.16248822,-25.968078,8.839417)">
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3074"
+       d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
+       style="fill:#aa0000;fill-opacity:1;stroke:none" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="path3074-7"
+       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.10169 C 355.22612,56.008196 388.35146,133.64656 321.55931,144.1017 z"
+       style="fill:#aa0000;fill-opacity:1;stroke:none" />
+  </g>
+</svg>

--- a/Numix-Circle/48x48/apps/ltspice.svg
+++ b/Numix-Circle/48x48/apps/ltspice.svg
@@ -5,25 +5,22 @@
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    viewBox="0 0 48 48"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   width="100%"
-   height="100%"
+   inkscape:version="0.91 r"
    sodipodi:docname="ltspice.svg">
   <metadata
-     id="metadata67">
+     id="metadata53">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -38,125 +35,97 @@
      inkscape:pageshadow="2"
      inkscape:window-width="1855"
      inkscape:window-height="1056"
-     id="namedview65"
+     id="namedview51"
      showgrid="false"
-     inkscape:zoom="11.313709"
-     inkscape:cx="27.844352"
-     inkscape:cy="20.144493"
+     inkscape:zoom="19.666667"
+     inkscape:cx="20.526719"
+     inkscape:cy="26.301112"
      inkscape:window-x="65"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
-     inkscape:current-layer="g29"
-     inkscape:snap-global="false">
+     inkscape:current-layer="g19">
     <inkscape:grid
        type="xygrid"
-       id="grid3012" />
+       id="grid4191" />
   </sodipodi:namedview>
   <defs
      id="defs4">
     <linearGradient
-       id="linearGradient3779">
-      <stop
-         id="stop3781"
-         offset="0"
-         style="stop-color:#dfcdcd;stop-opacity:1" />
-      <stop
-         id="stop3783"
-         offset="1"
-         style="stop-color:#e7d9d9;stop-opacity:1" />
-    </linearGradient>
-    <linearGradient
-       id="linearGradient3788">
-      <stop
-         style="stop-color:#dfcdcd;stop-opacity:1;"
-         offset="0"
-         id="stop3790" />
-      <stop
-         style="stop-color:#e6dada;stop-opacity:1;"
-         offset="1"
-         id="stop3792" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3788"
-       id="linearGradient3804"
-       x1="22.781593"
-       y1="38.592419"
-       x2="22.781593"
-       y2="4.2010102"
-       gradientUnits="userSpaceOnUse" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient3779"
-       id="linearGradient3009"
+       id="linearGradient3764"
+       x1="1"
+       x2="47"
        gradientUnits="userSpaceOnUse"
-       x1="1.0003443"
-       y1="46.996197"
-       x2="1.0003443"
-       y2="0.99788517" />
+       gradientTransform="matrix(0,-1,1,0,-1.5e-6,47.999998)">
+      <stop
+         style="stop-color:#dfcdcd;stop-opacity:1"
+         id="stop7" />
+      <stop
+         offset="1"
+         style="stop-color:#e7d9d9;stop-opacity:1"
+         id="stop9" />
+    </linearGradient>
   </defs>
   <g
-     id="g21">
+     id="g11">
     <path
        d="m 36.31 5 c 5.859 4.062 9.688 10.831 9.688 18.5 c 0 12.426 -10.07 22.5 -22.5 22.5 c -7.669 0 -14.438 -3.828 -18.5 -9.688 c 1.037 1.822 2.306 3.499 3.781 4.969 c 4.085 3.712 9.514 5.969 15.469 5.969 c 12.703 0 23 -10.298 23 -23 c 0 -5.954 -2.256 -11.384 -5.969 -15.469 c -1.469 -1.475 -3.147 -2.744 -4.969 -3.781 z m 4.969 3.781 c 3.854 4.113 6.219 9.637 6.219 15.719 c 0 12.703 -10.297 23 -23 23 c -6.081 0 -11.606 -2.364 -15.719 -6.219 c 4.16 4.144 9.883 6.719 16.219 6.719 c 12.703 0 23 -10.298 23 -23 c 0 -6.335 -2.575 -12.06 -6.719 -16.219 z"
        style="opacity:0.05"
-       id="path23" />
+       id="path13" />
     <path
        d="m 41.28 8.781 c 3.712 4.085 5.969 9.514 5.969 15.469 c 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 c 4.113 3.854 9.637 6.219 15.719 6.219 c 12.703 0 23 -10.298 23 -23 c 0 -6.081 -2.364 -11.606 -6.219 -15.719 z"
        style="opacity:0.1"
-       id="path25" />
+       id="path15" />
     <path
        d="m 31.25 2.375 c 8.615 3.154 14.75 11.417 14.75 21.13 c 0 12.426 -10.07 22.5 -22.5 22.5 c -9.708 0 -17.971 -6.135 -21.12 -14.75 a 23 23 0 0 0 44.875 -7 a 23 23 0 0 0 -16 -21.875 z"
        style="opacity:0.2"
-       id="path27" />
+       id="path17" />
   </g>
   <g
-     id="g29"
-     style="fill:url(#linearGradient3804);stroke:none;fill-opacity:1.0">
+     id="g19">
     <path
        d="m 24 1 c 12.703 0 23 10.297 23 23 c 0 12.703 -10.297 23 -23 23 -12.703 0 -23 -10.297 -23 -23 0 -12.703 10.297 -23 23 -23 z"
-       style="fill:url(#linearGradient3009);fill-opacity:1.0;stroke:none"
-       id="path31" />
+       style="fill:url(#linearGradient3764);fill-opacity:1"
+       id="path21" />
+    <g
+       transform="matrix(0.1198665,0,0,0.1194704,-11.721812,13.784112)"
+       id="g4193"
+       style="fill:#000000;fill-opacity:1;stroke:none;opacity:0.1">
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 Z"
+         id="path4195"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="fill:#000000;fill-opacity:1;stroke:none"
+         d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 Z"
+         id="path4197"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <g
+       style="fill:#c32828;fill-opacity:1;stroke:none"
+       id="g3094"
+       transform="matrix(0.1198665,0,0,0.1194704,-12.721812,12.784112)">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path3074"
+         d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 Z"
+         style="fill:#c32828;fill-opacity:1;stroke:none" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path3074-7"
+         d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 Z"
+         style="fill:#c32828;fill-opacity:1;stroke:none" />
+    </g>
   </g>
   <g
-     id="g61">
+     id="g47">
     <path
        d="m 40.03 7.531 c 3.712 4.084 5.969 9.514 5.969 15.469 0 12.703 -10.297 23 -23 23 c -5.954 0 -11.384 -2.256 -15.469 -5.969 4.178 4.291 10.01 6.969 16.469 6.969 c 12.703 0 23 -10.298 23 -23 0 -6.462 -2.677 -12.291 -6.969 -16.469 z"
        style="opacity:0.1"
-       id="path63" />
-  </g>
-  <g
-     transform="matrix(0.1198665,0,0,0.1194704,-11.721812,13.784112)"
-     id="g3791"
-     style="opacity:0.1;fill:#000000;fill-opacity:1;stroke:none">
-    <path
-       style="fill:#000000;fill-opacity:1;stroke:none"
-       d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
-       id="path3793"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
-    <path
-       style="fill:#000000;fill-opacity:1;stroke:none"
-       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 z"
-       id="path3795"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="ccccc" />
-  </g>
-  <g
-     style="fill:#c32828;fill-opacity:1;stroke:none"
-     id="g3094"
-     transform="matrix(0.1198665,0,0,0.1194704,-12.721812,12.784112)">
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       id="path3074"
-       d="m 291.15254,35.288136 c -7.60165,3.785631 -71.75599,104.011394 28.77966,93.762714 L 312.30508,144.10169 189.55932,144 C 257.48573,123.38163 224.36039,45.743279 291.15254,35.288136 z"
-       style="fill:#c32828;fill-opacity:1;stroke:none" />
-    <path
-       sodipodi:nodetypes="ccccc"
-       inkscape:connector-curvature="0"
-       id="path3074-7"
-       d="m 321.55931,144.1017 c 7.60165,-3.78563 71.75599,-104.011404 -28.77965,-93.762724 l 7.62711,-15.05084 122.74576,0.09889 C 355.22612,56.005396 388.35146,133.64656 321.55931,144.1017 z"
-       style="fill:#c32828;fill-opacity:1;stroke:none" />
+       id="path49" />
   </g>
 </svg>


### PR DESCRIPTION
I recently created icon for LTSpice, a electronics simulation software.
It doesn't run on Linux, but You can easily use it in WINE, so I thought You may want to consider adding its icon to the set.

This is my Icon:
![selection_527](https://cloud.githubusercontent.com/assets/6173262/13319880/1c6a799a-dbc5-11e5-9d6a-6b9793f3f451.png)

*(Again, sorry for that brown backround)*

I tried to follow guideline, but if something's wrong, let me know, I'm willing to fix it. ;)