### PR TITLE
Symlinks for KDE apps

### DIFF
--- a/Numix-Circle/48x48/apps/plasmadiscover.svg
+++ b/Numix-Circle/48x48/apps/plasmadiscover.svg
@@ -1,0 +1,1 @@
+muondiscover.svg

--- a/Numix-Circle/48x48/apps/spectacle.svg
+++ b/Numix-Circle/48x48/apps/spectacle.svg
@@ -1,0 +1,1 @@
+accessories-screenshot.svg


### PR DESCRIPTION
They got a new screenshot app and *Moun Discover* is now just *Discover*.