### PR TITLE
Symlinks for GNOME Photos and Totem

### DIFF
--- a/Numix-Circle/48x48/apps/org.gnome.Photos.svg
+++ b/Numix-Circle/48x48/apps/org.gnome.Photos.svg
@@ -1,0 +1,1 @@
+gnome-photos.svg

--- a/Numix-Circle/48x48/apps/org.gnome.Totem.svg
+++ b/Numix-Circle/48x48/apps/org.gnome.Totem.svg
@@ -1,0 +1,1 @@
+totem.svg


### PR DESCRIPTION
Looks like finally all GNOME apps will undergo the ``org.gnome`` treatment.

From what I heard it is neccessary for setting up xdg-bundles for some reason.