### PR TITLE
add symlink for openpht icon

### DIFF
--- a/Numix-Circle/48/apps/openpht.svg
+++ b/Numix-Circle/48/apps/openpht.svg
@@ -1,0 +1,1 @@
+plexhometheater.svg


### PR DESCRIPTION
This provides a symlink for an icon for OpenPHT, a community-driven Plex client. The [desktop file](https://github.com/RasPlex/OpenPHT/blob/openpht-1.6/plex/Resources/openpht.desktop.in) in its git repo refers to the icon "openpht", which is missing from this repo.

Let me know if this is not the place to be submitting this pull request.