### PR TITLE
change code.svg to symlink to visualstudiocode.svg

### DIFF
--- a/Numix-Circle/48/apps/code.svg
+++ b/Numix-Circle/48/apps/code.svg
@@ -1,1 +1,1 @@
-text-editor.svg
+visualstudiocode.svg


### PR DESCRIPTION
Visual Studio Code's default icon name is simply 'code', instead of 'vscode' or 'visualstudiocode'. This causes the wrong icon to be displayed when it's installed and Numix-Circle is used as the icon theme.

I've removed the `code.svg` file and, in its place, put a symlink to `visualstudiocode.svg` to correct this. Don't know if this breaks anything else.